### PR TITLE
Prep package.json for first npm publish (v0.0.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draftwise",
-  "version": "1.0.0",
-  "description": "<h1 align=\"center\">Draftwise</h1>",
+  "version": "0.0.1",
+  "description": "Codebase-aware product specs. AI scans your repo, then drafts specs that fit it.",
   "main": "src/index.js",
   "scripts": {
     "test": "vitest run",
@@ -13,8 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/4nkur/draftwise.git"
   },
-  "keywords": [],
-  "author": "",
+  "author": "Ankur Goyal <04.ankur@gmail.com> (https://github.com/4nkur)",
   "license": "MIT",
   "type": "module",
   "bugs": {
@@ -34,5 +33,21 @@
   },
   "dependencies": {
     "@inquirer/prompts": "^8.4.2"
-  }
+  },
+  "files": [
+    "bin",
+    "src",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "product-spec",
+    "product-management",
+    "spec-driven-development",
+    "ai-agent",
+    "cli",
+    "claude-code",
+    "cursor",
+    "codebase-aware"
+  ]
 }


### PR DESCRIPTION
Sets a real description, search-friendly keywords (product-spec, spec-driven-development, claude-code, cursor, etc.), public author identity, and a files allowlist so only bin/, src/, README, and LICENSE ship to npm. Drops version to 0.0.1 — only the init command exists, so 1.0.0 would have been premature and unrepublishable.