### PR TITLE
Implement draftwise scan with AI plumbing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "draftwise",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "draftwise",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/prompts": "^8.4.2"
+        "@anthropic-ai/sdk": "^0.91.1",
+        "@inquirer/prompts": "^8.4.2",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "draftwise": "bin/draftwise.js"
@@ -21,6 +23,35 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1608,6 +1639,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -2326,6 +2370,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2566,6 +2616,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@inquirer/prompts": "^8.4.2"
+    "@anthropic-ai/sdk": "^0.91.1",
+    "@inquirer/prompts": "^8.4.2",
+    "yaml": "^2.8.3"
   },
   "files": [
     "bin",

--- a/src/ai/prompts/scan.js
+++ b/src/ai/prompts/scan.js
@@ -1,0 +1,55 @@
+export const SYSTEM = `You are Draftwise, a codebase-aware product spec drafting tool.
+
+Your job in this turn is to read structured scanner output from a real codebase and produce a single overview.md document. The overview is the team's mental model of the product as it exists today — read by PMs, engineers, and new hires.
+
+Hard rules:
+- Be concrete. Reference real file paths, real route paths, real model names from the scanner output. Do NOT invent.
+- If the scanner data is sparse or ambiguous, say so plainly. Don't paper over gaps with generic prose.
+- Keep prose tight. PMs read this; verbosity erodes trust.
+- Output valid markdown only. No preamble like "Here is the overview" — start directly with the document.
+`;
+
+export function buildPrompt({ scan, packageMeta }) {
+  const parts = [
+    'Generate an overview.md for this codebase. Use exactly these top-level sections, in order:',
+    '',
+    '# <Product name>  (use the package name as a starting point)',
+    '> One-sentence description of what this product appears to do, inferred from the codebase.',
+    '',
+    '## What this codebase is',
+    'A short paragraph (3-5 sentences) framing the product in plain language. Cite the framework(s) detected.',
+    '',
+    '## Major flows',
+    'Bullet list of the top 5-8 user-facing flows you can infer from routes + components. For each: name, one-line description, and the entry-point file(s).',
+    '',
+    '## API surface',
+    'Table or list of the routes/endpoints detected. For each: method, path, file. Group by area if natural.',
+    '',
+    '## Data model',
+    'Bullet list of the data models/tables detected. For each: name, file, and 2-3 of its most important fields/relationships.',
+    '',
+    '## Components',
+    'Bullet list of the most important UI components (cap at 15). Group by directory.',
+    '',
+    '## Integrations & external dependencies',
+    'Bullet list of notable third-party dependencies inferred from package.json that hint at integrations (auth providers, payments, AI, queues, observability, etc.). Skip generic build tooling.',
+    '',
+    '## Gaps in this overview',
+    'A short section listing what the scanner could NOT determine — e.g. flows the scanner missed, models not yet parsed, etc. Be honest.',
+    '',
+    '---',
+    '',
+    'Scanner output (structured JSON):',
+    '```json',
+    JSON.stringify(scan, null, 2),
+    '```',
+    '',
+    'Package metadata:',
+    '```json',
+    JSON.stringify(packageMeta, null, 2),
+    '```',
+  ];
+  return parts.join('\n');
+}
+
+export const AGENT_INSTRUCTION = `The scanner data above describes a real codebase. Generate an overview.md following the section structure shown, grounded only in what the scanner produced. Write the file to .draftwise/overview.md, replacing any placeholder content. Do not invent files, routes, or models that aren't in the scanner output.`;

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -1,0 +1,29 @@
+import { complete as claudeComplete } from './providers/claude.js';
+
+const ADAPTERS = {
+  claude: claudeComplete,
+  openai: notImplemented('openai'),
+  gemini: notImplemented('gemini'),
+};
+
+function notImplemented(name) {
+  return () => {
+    throw new Error(
+      `The ${name} provider isn't wired up yet. Use Claude for now (set ai.provider: claude in .draftwise/config.yaml) or run draftwise inside a coding agent.`,
+    );
+  };
+}
+
+export async function complete({ provider, apiKeyEnv, model, system, prompt }) {
+  const adapter = ADAPTERS[provider];
+  if (!adapter) {
+    throw new Error(`Unknown AI provider "${provider}".`);
+  }
+  const apiKey = process.env[apiKeyEnv];
+  if (!apiKey) {
+    throw new Error(
+      `Environment variable ${apiKeyEnv} is not set. Export it before running this command.`,
+    );
+  }
+  return adapter({ apiKey, model, system, prompt });
+}

--- a/src/ai/providers/claude.js
+++ b/src/ai/providers/claude.js
@@ -1,0 +1,24 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-6';
+const MAX_TOKENS = 8192;
+
+export async function complete({ apiKey, model, system, prompt }) {
+  const client = new Anthropic({ apiKey });
+  const response = await client.messages.create({
+    model: model || DEFAULT_MODEL,
+    max_tokens: MAX_TOKENS,
+    system,
+    messages: [{ role: 'user', content: prompt }],
+  });
+
+  const text = response.content
+    .filter((block) => block.type === 'text')
+    .map((block) => block.text)
+    .join('');
+
+  if (!text) {
+    throw new Error('Claude returned an empty response.');
+  }
+  return text;
+}

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -1,0 +1,100 @@
+import { writeFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { scan as defaultScan } from '../core/scanner.js';
+import { loadConfig as defaultLoadConfig } from '../utils/config.js';
+import { complete as defaultComplete } from '../ai/provider.js';
+import { SYSTEM, buildPrompt, AGENT_INSTRUCTION } from '../ai/prompts/scan.js';
+
+async function pathExists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function summarize(scan) {
+  return {
+    files: scan.files.length,
+    frameworks: scan.frameworks,
+    orms: scan.orms,
+    routes: scan.routes.length,
+    components: scan.components.length,
+    models: scan.models.length,
+  };
+}
+
+export default async function scanCommand(_args = [], deps = {}) {
+  const cwd = deps.cwd ?? process.cwd();
+  const log = deps.log ?? ((msg) => console.log(msg));
+  const scan = deps.scan ?? defaultScan;
+  const loadConfig = deps.loadConfig ?? defaultLoadConfig;
+  const complete = deps.complete ?? defaultComplete;
+
+  const draftwiseDir = join(cwd, '.draftwise');
+  if (!(await pathExists(draftwiseDir))) {
+    throw new Error(
+      '.draftwise/ not found. Run `draftwise init` first.',
+    );
+  }
+
+  const config = await loadConfig(cwd);
+
+  log('Scanning repo...');
+  const result = await scan(cwd);
+
+  if (!result.files || result.files.length === 0) {
+    throw new Error(
+      `No source files found under ${cwd}. Run \`draftwise scan\` from your repo root.`,
+    );
+  }
+
+  const summary = summarize(result);
+  log(
+    `  ${summary.files} files · ${summary.frameworks.join(', ') || 'no framework detected'} · ${summary.routes} routes · ${summary.components} components · ${summary.models} models`,
+  );
+  log('');
+
+  const scanForPrompt = {
+    frameworks: result.frameworks,
+    orms: result.orms,
+    routes: result.routes,
+    components: result.components.slice(0, 50),
+    models: result.models,
+    fileCount: result.files.length,
+    sampleFiles: result.files.slice(0, 30),
+  };
+
+  if (config.mode === 'agent') {
+    log('Agent mode — handing scanner data off to your coding agent.');
+    log('');
+    log('---');
+    log('SCANNER OUTPUT');
+    log('```json');
+    log(JSON.stringify(scanForPrompt, null, 2));
+    log('```');
+    log('');
+    log('PACKAGE METADATA');
+    log('```json');
+    log(JSON.stringify(result.packageMeta, null, 2));
+    log('```');
+    log('');
+    log('INSTRUCTION');
+    log(AGENT_INSTRUCTION);
+    return;
+  }
+
+  log(`API mode — calling ${config.provider}...`);
+  const overview = await complete({
+    provider: config.provider,
+    apiKeyEnv: config.apiKeyEnv,
+    model: config.model,
+    system: SYSTEM,
+    prompt: buildPrompt({ scan: scanForPrompt, packageMeta: result.packageMeta }),
+  });
+
+  await writeFile(join(draftwiseDir, 'overview.md'), overview, 'utf8');
+  log('');
+  log('Wrote .draftwise/overview.md');
+}

--- a/src/core/scanner.js
+++ b/src/core/scanner.js
@@ -1,5 +1,5 @@
-import { readdir } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { readdir, readFile, access } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
 
 const IGNORE_DIRS = new Set([
   'node_modules',
@@ -32,10 +32,59 @@ const CODE_EXTENSIONS = new Set([
   '.c', '.cc', '.cpp', '.h', '.hpp',
 ]);
 
+const COMPONENT_EXTENSIONS = new Set(['.jsx', '.tsx', '.vue', '.svelte']);
+
+const FRAMEWORK_DEPS = {
+  next: 'Next.js',
+  '@remix-run/react': 'Remix',
+  'react-router-dom': 'React Router',
+  react: 'React',
+  vue: 'Vue',
+  svelte: 'Svelte',
+  '@sveltejs/kit': 'SvelteKit',
+  nuxt: 'Nuxt',
+  express: 'Express',
+  fastify: 'Fastify',
+  '@hapi/hapi': 'Hapi',
+  koa: 'Koa',
+  '@nestjs/core': 'NestJS',
+};
+
+const ORM_DEPS = {
+  '@prisma/client': 'Prisma',
+  prisma: 'Prisma',
+  mongoose: 'Mongoose',
+  sequelize: 'Sequelize',
+  'drizzle-orm': 'Drizzle',
+  typeorm: 'TypeORM',
+  knex: 'Knex',
+};
+
 export async function scan(root) {
   const files = [];
   await walk(root, root, files);
-  return { root, files };
+
+  const packageMeta = await readPackageJson(root);
+  const frameworks = detectFrameworks(packageMeta);
+  const orms = detectOrms(packageMeta);
+
+  const components = files
+    .filter((f) => COMPONENT_EXTENSIONS.has(extOf(f)))
+    .map((file) => ({ name: baseName(file), file }));
+
+  const routes = await detectRoutes(root, files);
+  const models = await detectModels(root, files, orms);
+
+  return {
+    root,
+    files,
+    packageMeta,
+    frameworks,
+    orms,
+    routes,
+    components,
+    models,
+  };
 }
 
 async function walk(root, dir, out) {
@@ -52,11 +101,217 @@ async function walk(root, dir, out) {
     if (entry.isDirectory()) {
       await walk(root, full, out);
     } else if (entry.isFile()) {
-      const dot = entry.name.lastIndexOf('.');
-      if (dot < 0) continue;
-      if (CODE_EXTENSIONS.has(entry.name.slice(dot).toLowerCase())) {
-        out.push(relative(root, full).split('\\').join('/'));
+      if (CODE_EXTENSIONS.has(extOf(entry.name))) {
+        out.push(toPosix(relative(root, full)));
       }
     }
   }
+}
+
+function extOf(name) {
+  const dot = name.lastIndexOf('.');
+  return dot < 0 ? '' : name.slice(dot).toLowerCase();
+}
+
+function baseName(file) {
+  const slash = file.lastIndexOf('/');
+  const name = slash < 0 ? file : file.slice(slash + 1);
+  const dot = name.lastIndexOf('.');
+  return dot < 0 ? name : name.slice(0, dot);
+}
+
+function toPosix(p) {
+  return p.split(sep).join('/');
+}
+
+async function readPackageJson(root) {
+  const path = join(root, 'package.json');
+  try {
+    const raw = await readFile(path, 'utf8');
+    const pkg = JSON.parse(raw);
+    return {
+      name: pkg.name,
+      version: pkg.version,
+      description: pkg.description,
+      dependencies: Object.keys(pkg.dependencies ?? {}),
+      devDependencies: Object.keys(pkg.devDependencies ?? {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function detectFrameworks(packageMeta) {
+  if (!packageMeta) return [];
+  const deps = new Set([
+    ...(packageMeta.dependencies ?? []),
+    ...(packageMeta.devDependencies ?? []),
+  ]);
+  const found = [];
+  for (const [pkg, label] of Object.entries(FRAMEWORK_DEPS)) {
+    if (deps.has(pkg)) found.push(label);
+  }
+  return [...new Set(found)];
+}
+
+function detectOrms(packageMeta) {
+  if (!packageMeta) return [];
+  const deps = new Set([
+    ...(packageMeta.dependencies ?? []),
+    ...(packageMeta.devDependencies ?? []),
+  ]);
+  const found = [];
+  for (const [pkg, label] of Object.entries(ORM_DEPS)) {
+    if (deps.has(pkg)) found.push(label);
+  }
+  return [...new Set(found)];
+}
+
+async function detectRoutes(root, files) {
+  const routes = [];
+
+  for (const file of files) {
+    const next = nextRouteFromFile(file);
+    if (next) routes.push(next);
+  }
+
+  await detectFrameworkRoutes(root, files, routes);
+
+  return routes;
+}
+
+function nextRouteFromFile(file) {
+  const m = file.match(/^(?:src\/)?pages\/(.+)\.(?:tsx?|jsx?|mdx?)$/);
+  if (m) {
+    let path = '/' + m[1].replace(/\/index$/, '').replace(/^index$/, '');
+    if (path === '/') path = '/';
+    if (path.startsWith('/api/')) {
+      return { method: 'ANY', path, file, source: 'next-pages' };
+    }
+    return { method: 'GET', path, file, source: 'next-pages' };
+  }
+  const a = file.match(/^(?:src\/)?app\/(.+)\/(page|route)\.(?:tsx?|jsx?)$/);
+  if (a) {
+    const segments = a[1];
+    const kind = a[2];
+    const path = '/' + segments;
+    if (kind === 'route') {
+      return { method: 'ANY', path, file, source: 'next-app-route' };
+    }
+    return { method: 'GET', path, file, source: 'next-app-page' };
+  }
+  return null;
+}
+
+const TEST_FILE_RE = /(?:^|\/)(?:test|tests|__tests__|spec|specs)\/|\.(?:test|spec)\.[mc]?[jt]sx?$/;
+
+async function detectFrameworkRoutes(root, files, out) {
+  const RE = /\b(?:app|router|fastify|koa|server)\s*\.\s*(get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/gi;
+  const candidates = files.filter(
+    (f) => /\.(?:[mc]?[jt]s)$/.test(f) && !TEST_FILE_RE.test(f),
+  );
+  for (const file of candidates) {
+    let content;
+    try {
+      content = await readFile(join(root, file), 'utf8');
+    } catch {
+      continue;
+    }
+    if (content.length > 200_000) continue;
+    let m;
+    while ((m = RE.exec(content)) !== null) {
+      out.push({
+        method: m[1].toUpperCase(),
+        path: m[2],
+        file,
+        source: 'http-call',
+      });
+    }
+  }
+}
+
+async function detectModels(root, files, orms) {
+  const models = [];
+
+  if (orms.includes('Prisma')) {
+    models.push(...(await parsePrismaSchema(root)));
+  }
+  if (orms.includes('Mongoose')) {
+    models.push(...(await parseMongoose(root, files)));
+  }
+  if (orms.includes('Drizzle')) {
+    models.push(...(await parseDrizzle(root, files)));
+  }
+
+  return models;
+}
+
+async function parsePrismaSchema(root) {
+  const path = join(root, 'prisma', 'schema.prisma');
+  try {
+    await access(path);
+  } catch {
+    return [];
+  }
+  const content = await readFile(path, 'utf8');
+  const out = [];
+  const RE = /^model\s+(\w+)\s*\{([^}]*)\}/gm;
+  let m;
+  while ((m = RE.exec(content)) !== null) {
+    const fields = m[2]
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('//') && !l.startsWith('@@'))
+      .map((l) => l.split(/\s+/)[0])
+      .filter(Boolean)
+      .slice(0, 10);
+    out.push({
+      name: m[1],
+      file: 'prisma/schema.prisma',
+      fields,
+      source: 'prisma',
+    });
+  }
+  return out;
+}
+
+async function parseMongoose(root, files) {
+  const out = [];
+  const RE_MODEL = /mongoose\.model\s*\(\s*['"`](\w+)['"`]/g;
+  for (const file of files.filter(
+    (f) => /\.(?:[mc]?[jt]s)$/.test(f) && !TEST_FILE_RE.test(f),
+  )) {
+    let content;
+    try {
+      content = await readFile(join(root, file), 'utf8');
+    } catch {
+      continue;
+    }
+    if (!content.includes('mongoose.model')) continue;
+    let m;
+    while ((m = RE_MODEL.exec(content)) !== null) {
+      out.push({ name: m[1], file, fields: [], source: 'mongoose' });
+    }
+  }
+  return out;
+}
+
+async function parseDrizzle(root, files) {
+  const out = [];
+  const RE = /(?:pgTable|sqliteTable|mysqlTable)\s*\(\s*['"`](\w+)['"`]/g;
+  for (const file of files.filter(
+    (f) => /\.(?:[mc]?[jt]s)$/.test(f) && !TEST_FILE_RE.test(f),
+  )) {
+    let content;
+    try {
+      content = await readFile(join(root, file), 'utf8');
+    } catch {
+      continue;
+    }
+    let m;
+    while ((m = RE.exec(content)) !== null) {
+      out.push({ name: m[1], file, fields: [], source: 'drizzle' });
+    }
+  }
+  return out;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const COMMANDS = {
   init: () => import('./commands/init.js'),
+  scan: () => import('./commands/scan.js'),
 };
 
 const HELP = `draftwise — codebase-aware spec drafting
@@ -9,6 +10,7 @@ Usage:
 
 Commands:
   init              Scan codebase and set up .draftwise/
+  scan              Refresh the codebase overview
 
 Run "draftwise <command> --help" for command-specific help (coming soon).
 `;

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,0 +1,52 @@
+import { readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+const VALID_MODES = new Set(['agent', 'api']);
+const VALID_PROVIDERS = new Set(['claude', 'openai', 'gemini']);
+
+export async function loadConfig(cwd = process.cwd()) {
+  const path = join(cwd, '.draftwise', 'config.yaml');
+  try {
+    await access(path);
+  } catch {
+    throw new Error(
+      '.draftwise/config.yaml not found. Run `draftwise init` first.',
+    );
+  }
+
+  const raw = await readFile(path, 'utf8');
+  let parsed;
+  try {
+    parsed = parseYaml(raw);
+  } catch (err) {
+    throw new Error(`Failed to parse .draftwise/config.yaml: ${err.message}`);
+  }
+
+  const ai = parsed?.ai;
+  if (!ai || !VALID_MODES.has(ai.mode)) {
+    throw new Error(
+      '.draftwise/config.yaml is missing a valid `ai.mode` (agent or api).',
+    );
+  }
+
+  if (ai.mode === 'api') {
+    if (!VALID_PROVIDERS.has(ai.provider)) {
+      throw new Error(
+        '.draftwise/config.yaml has `ai.mode: api` but is missing a valid `ai.provider` (claude, openai, or gemini).',
+      );
+    }
+    if (!ai.api_key_env || typeof ai.api_key_env !== 'string') {
+      throw new Error(
+        '.draftwise/config.yaml has `ai.mode: api` but is missing `ai.api_key_env`.',
+      );
+    }
+  }
+
+  return {
+    mode: ai.mode,
+    provider: ai.provider,
+    apiKeyEnv: ai.api_key_env,
+    model: ai.model || '',
+  };
+}

--- a/test/commands/scan.test.js
+++ b/test/commands/scan.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import scanCommand from '../../src/commands/scan.js';
+
+const SAMPLE_SCAN = {
+  root: '/repo',
+  files: ['src/index.js', 'src/foo.ts'],
+  packageMeta: { name: 'demo', dependencies: ['next'], devDependencies: [] },
+  frameworks: ['Next.js'],
+  orms: [],
+  routes: [{ method: 'GET', path: '/', file: 'app/page.tsx' }],
+  components: [{ name: 'Home', file: 'app/page.tsx' }],
+  models: [],
+};
+
+describe('draftwise scan', () => {
+  let dir;
+  let logs;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-scan-'));
+    await mkdir(join(dir, '.draftwise'));
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('errors if .draftwise/ is missing', async () => {
+    await rm(join(dir, '.draftwise'), { recursive: true });
+    await expect(
+      scanCommand([], {
+        cwd: dir,
+        log: (m) => logs.push(m),
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => 'unused',
+      }),
+    ).rejects.toThrow(/Run `draftwise init` first/);
+  });
+
+  it('in agent mode, prints scanner data and instruction without writing overview.md', async () => {
+    await scanCommand([], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({ mode: 'agent' }),
+      complete: async () => {
+        throw new Error('should not be called in agent mode');
+      },
+    });
+
+    const output = logs.join('\n');
+    expect(output).toContain('SCANNER OUTPUT');
+    expect(output).toContain('Next.js');
+    expect(output).toContain('INSTRUCTION');
+
+    await expect(readFile(join(dir, '.draftwise', 'overview.md'))).rejects.toThrow();
+  });
+
+  it('in api mode, calls the model and writes overview.md', async () => {
+    let captured;
+    await scanCommand([], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+      }),
+      complete: async (args) => {
+        captured = args;
+        return '# Overview\n\nGenerated content here.';
+      },
+    });
+
+    expect(captured.provider).toBe('claude');
+    expect(captured.system).toContain('Draftwise');
+    expect(captured.prompt).toContain('Next.js');
+
+    const overview = await readFile(join(dir, '.draftwise', 'overview.md'), 'utf8');
+    expect(overview).toContain('# Overview');
+  });
+
+  it('errors when scan returns zero files', async () => {
+    await expect(
+      scanCommand([], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => ({ ...SAMPLE_SCAN, files: [] }),
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/No source files/);
+  });
+});

--- a/test/core/scanner.test.js
+++ b/test/core/scanner.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { scan } from '../../src/core/scanner.js';
+
+async function writeFixture(root, files) {
+  for (const [path, content] of Object.entries(files)) {
+    const full = join(root, path);
+    const dir = full.slice(0, full.lastIndexOf(/[\\/]/.exec(full)?.[0] ?? '/'));
+    await mkdir(dir, { recursive: true });
+    await writeFile(full, content, 'utf8');
+  }
+}
+
+describe('scanner', () => {
+  let dir;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-scanner-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('detects framework and ORM from package.json', async () => {
+    await writeFixture(dir, {
+      'package.json': JSON.stringify({
+        name: 'demo',
+        dependencies: { next: '^14.0.0', '@prisma/client': '^5.0.0' },
+        devDependencies: { prisma: '^5.0.0' },
+      }),
+      'src/index.ts': '// noop',
+    });
+
+    const result = await scan(dir);
+    expect(result.frameworks).toContain('Next.js');
+    expect(result.orms).toContain('Prisma');
+    expect(result.packageMeta.name).toBe('demo');
+  });
+
+  it('detects Next.js app-router routes', async () => {
+    await writeFixture(dir, {
+      'package.json': JSON.stringify({ dependencies: { next: '^14.0.0' } }),
+      'app/page.tsx': 'export default function Home() {}',
+      'app/dashboard/page.tsx': 'export default function Dash() {}',
+      'app/api/users/route.ts': 'export async function GET() {}',
+    });
+
+    const result = await scan(dir);
+    const paths = result.routes.map((r) => r.path).sort();
+    expect(paths).toContain('/dashboard');
+    expect(paths).toContain('/api/users');
+  });
+
+  it('detects Express routes from source', async () => {
+    await writeFixture(dir, {
+      'package.json': JSON.stringify({ dependencies: { express: '^4.18.0' } }),
+      'src/server.js': `
+        const app = require('express')();
+        app.get('/healthz', (req, res) => res.send('ok'));
+        app.post('/api/users', (req, res) => {});
+      `,
+    });
+
+    const result = await scan(dir);
+    const methods = result.routes.map((r) => `${r.method} ${r.path}`).sort();
+    expect(methods).toContain('GET /healthz');
+    expect(methods).toContain('POST /api/users');
+  });
+
+  it('detects React components', async () => {
+    await writeFixture(dir, {
+      'package.json': JSON.stringify({ dependencies: { react: '^18.0.0' } }),
+      'src/components/Button.tsx': 'export const Button = () => null;',
+      'src/components/Card.jsx': 'export const Card = () => null;',
+    });
+
+    const result = await scan(dir);
+    const names = result.components.map((c) => c.name).sort();
+    expect(names).toEqual(['Button', 'Card']);
+  });
+
+  it('parses Prisma models from schema.prisma', async () => {
+    await writeFixture(dir, {
+      'package.json': JSON.stringify({
+        dependencies: { '@prisma/client': '^5.0.0' },
+      }),
+      'prisma/schema.prisma': `
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id    String  @id @default(cuid())
+  email String  @unique
+  posts Post[]
+}
+
+model Post {
+  id     String @id @default(cuid())
+  title  String
+  authorId String
+}
+      `,
+    });
+
+    const result = await scan(dir);
+    const names = result.models.map((m) => m.name).sort();
+    expect(names).toEqual(['Post', 'User']);
+    const user = result.models.find((m) => m.name === 'User');
+    expect(user.fields).toContain('id');
+    expect(user.fields).toContain('email');
+  });
+
+  it('ignores node_modules and .git', async () => {
+    await writeFixture(dir, {
+      'package.json': '{}',
+      'src/app.js': '// real',
+      'node_modules/foo/index.js': '// noise',
+      '.git/HEAD': 'ref: refs/heads/main',
+    });
+    const result = await scan(dir);
+    expect(result.files).toContain('src/app.js');
+    expect(result.files.find((f) => f.startsWith('node_modules/'))).toBeUndefined();
+  });
+});

--- a/test/utils/config.test.js
+++ b/test/utils/config.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadConfig } from '../../src/utils/config.js';
+
+describe('loadConfig', () => {
+  let dir;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-config-'));
+    await mkdir(join(dir, '.draftwise'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('reads agent mode config', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: agent\n',
+      'utf8',
+    );
+    const config = await loadConfig(dir);
+    expect(config).toEqual({
+      mode: 'agent',
+      provider: undefined,
+      apiKeyEnv: undefined,
+      model: '',
+    });
+  });
+
+  it('reads api mode config with provider and api_key_env', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: api\n  provider: claude\n  api_key_env: ANTHROPIC_API_KEY\n  model: ""\n',
+      'utf8',
+    );
+    const config = await loadConfig(dir);
+    expect(config.mode).toBe('api');
+    expect(config.provider).toBe('claude');
+    expect(config.apiKeyEnv).toBe('ANTHROPIC_API_KEY');
+  });
+
+  it('errors when config.yaml is missing', async () => {
+    await expect(loadConfig(dir)).rejects.toThrow(/config\.yaml not found/);
+  });
+
+  it('errors on invalid mode', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: weird\n',
+      'utf8',
+    );
+    await expect(loadConfig(dir)).rejects.toThrow(/valid `ai\.mode`/);
+  });
+
+  it('errors when api mode is missing api_key_env', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: api\n  provider: claude\n',
+      'utf8',
+    );
+    await expect(loadConfig(dir)).rejects.toThrow(/api_key_env/);
+  });
+});


### PR DESCRIPTION
Adds the scan command and the foundations for every AI-driven command that follows. Three layers:

- src/utils/config.js reads .draftwise/config.yaml (yaml package).
- src/ai/provider.js routes calls by provider; src/ai/providers/claude.js wraps @anthropic-ai/sdk. OpenAI and Gemini are stubbed with a clear not-yet-wired-up error.
- src/core/scanner.js gains framework detection (Next/Express/Fastify/ React/Vue/Svelte/etc), Next pages+app router parsing, regex-based Express/Fastify/Koa route detection, React/Vue/Svelte component listing, and Prisma/Mongoose/Drizzle model parsing. Test files are excluded from route detection (caught a bogus match in our own scanner.test.js fixtures).

scan branches on config.mode: api mode calls the model and writes overview.md; agent mode dumps structured scanner data + an instruction to stdout for the host coding agent (Claude Code, Cursor, etc.) to consume and write overview.md itself.

20 tests across config, scanner, and command. Smoke-tested in agent mode against this repo — zero spurious routes after the test-file fix.