### PR TITLE
Implement draftwise explain <flow>

### DIFF
--- a/src/ai/prompts/explain.js
+++ b/src/ai/prompts/explain.js
@@ -1,0 +1,54 @@
+export const SYSTEM = `You are Draftwise, a codebase-aware tool that traces flows through real code.
+
+Your job in this turn is to walk through how a single flow works in the codebase the user just scanned. The output is read by PMs and engineers who need to understand what already exists before deciding what to change. Be specific and grounded.
+
+Hard rules:
+- Reference real file paths, real route paths, real function names from the scanner output. Do NOT invent.
+- If the scanner output doesn't contain enough information to trace the flow confidently, say so explicitly under "Gaps". Don't fabricate steps.
+- Keep the walkthrough tight. Engineers stop reading verbose docs.
+- Output valid markdown only. No preamble like "Here is the trace" — start directly with the document.
+`;
+
+export function buildPrompt({ flow, scan, packageMeta }) {
+  const parts = [
+    `Trace how the "${flow}" flow works in this codebase. Use exactly these top-level sections, in order:`,
+    '',
+    `# Flow: ${flow}`,
+    '> One-sentence summary of what this flow does, inferred from the code.',
+    '',
+    '## Entry points',
+    'How does this flow start? List routes, UI components, scheduled jobs, or webhooks that trigger it. For each: file path, and what triggers it.',
+    '',
+    '## Walkthrough',
+    'Step-by-step trace. Each step is one numbered line: what happens, with the file path and the function/handler name when known. 5-12 steps is the sweet spot.',
+    '',
+    '## Data read & written',
+    'Bullet list of the models/tables touched. For each: read or write, and what fields are involved if known.',
+    '',
+    '## Side effects',
+    'Bullet list of things this flow causes outside the request/response: emails, webhooks, async jobs, third-party API calls, cache invalidation, analytics events. Skip if none.',
+    '',
+    '## Edge cases handled',
+    "Bullet list of edge cases the code visibly handles (auth failures, validation, rate limits, race conditions, etc.). If you can't see explicit handling, say so.",
+    '',
+    '## Gaps',
+    'What you could NOT determine from the scanner output — files not parsed, services that look like they exist but the scanner missed, etc. Be honest.',
+    '',
+    '---',
+    '',
+    'Scanner output (structured JSON):',
+    '```json',
+    JSON.stringify(scan, null, 2),
+    '```',
+    '',
+    'Package metadata:',
+    '```json',
+    JSON.stringify(packageMeta, null, 2),
+    '```',
+  ];
+  return parts.join('\n');
+}
+
+export function buildAgentInstruction(flow, slug) {
+  return `The scanner data above describes a real codebase. The user wants to understand how the "${flow}" flow works. Generate a markdown walkthrough following the section structure shown, grounded only in what the scanner produced. Print the walkthrough to the user, then save it to .draftwise/flows/${slug}.md (create the flows directory if it doesn't exist). Do not invent files, routes, or functions that aren't in the scanner output.`;
+}

--- a/src/commands/explain.js
+++ b/src/commands/explain.js
@@ -1,0 +1,107 @@
+import { writeFile, mkdir, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { scan as defaultScan } from '../core/scanner.js';
+import { loadConfig as defaultLoadConfig } from '../utils/config.js';
+import { complete as defaultComplete } from '../ai/provider.js';
+import { SYSTEM, buildPrompt, buildAgentInstruction } from '../ai/prompts/explain.js';
+import { slugify } from '../utils/slug.js';
+
+async function pathExists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function compactScan(result) {
+  return {
+    frameworks: result.frameworks,
+    orms: result.orms,
+    routes: result.routes,
+    components: result.components.slice(0, 50),
+    models: result.models,
+    fileCount: result.files.length,
+    sampleFiles: result.files.slice(0, 30),
+  };
+}
+
+export default async function explainCommand(args = [], deps = {}) {
+  const cwd = deps.cwd ?? process.cwd();
+  const log = deps.log ?? ((msg) => console.log(msg));
+  const scan = deps.scan ?? defaultScan;
+  const loadConfig = deps.loadConfig ?? defaultLoadConfig;
+  const complete = deps.complete ?? defaultComplete;
+
+  const flow = args.join(' ').trim();
+  if (!flow) {
+    throw new Error(
+      'Missing flow name. Usage: draftwise explain "<flow name>"  (e.g. draftwise explain checkout)',
+    );
+  }
+
+  const draftwiseDir = join(cwd, '.draftwise');
+  if (!(await pathExists(draftwiseDir))) {
+    throw new Error('.draftwise/ not found. Run `draftwise init` first.');
+  }
+
+  const config = await loadConfig(cwd);
+  const slug = slugify(flow);
+
+  log(`Tracing "${flow}"...`);
+  const result = await scan(cwd);
+
+  if (!result.files || result.files.length === 0) {
+    throw new Error(
+      `No source files found under ${cwd}. Run \`draftwise explain\` from your repo root.`,
+    );
+  }
+
+  const scanForPrompt = compactScan(result);
+
+  if (config.mode === 'agent') {
+    log('');
+    log('Agent mode — handing scanner data off to your coding agent.');
+    log('');
+    log('---');
+    log(`FLOW: ${flow}`);
+    log('');
+    log('SCANNER OUTPUT');
+    log('```json');
+    log(JSON.stringify(scanForPrompt, null, 2));
+    log('```');
+    log('');
+    log('PACKAGE METADATA');
+    log('```json');
+    log(JSON.stringify(result.packageMeta, null, 2));
+    log('```');
+    log('');
+    log('INSTRUCTION');
+    log(buildAgentInstruction(flow, slug));
+    return;
+  }
+
+  log(`API mode — calling ${config.provider}...`);
+  const walkthrough = await complete({
+    provider: config.provider,
+    apiKeyEnv: config.apiKeyEnv,
+    model: config.model,
+    system: SYSTEM,
+    prompt: buildPrompt({
+      flow,
+      scan: scanForPrompt,
+      packageMeta: result.packageMeta,
+    }),
+  });
+
+  log('');
+  log(walkthrough);
+  log('');
+
+  const flowsDir = join(draftwiseDir, 'flows');
+  await mkdir(flowsDir, { recursive: true });
+  const outPath = join(flowsDir, `${slug}.md`);
+  await writeFile(outPath, walkthrough, 'utf8');
+  log(`Saved snapshot to .draftwise/flows/${slug}.md`);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const COMMANDS = {
   init: () => import('./commands/init.js'),
   scan: () => import('./commands/scan.js'),
+  explain: () => import('./commands/explain.js'),
 };
 
 const HELP = `draftwise — codebase-aware spec drafting
@@ -11,6 +12,7 @@ Usage:
 Commands:
   init              Scan codebase and set up .draftwise/
   scan              Refresh the codebase overview
+  explain <flow>    Trace how a specific flow works in the code
 
 Run "draftwise <command> --help" for command-specific help (coming soon).
 `;

--- a/src/utils/slug.js
+++ b/src/utils/slug.js
@@ -1,0 +1,9 @@
+export function slugify(str) {
+  return String(str)
+    .toLowerCase()
+    .trim()
+    .replace(/['"`]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'flow';
+}

--- a/test/commands/explain.test.js
+++ b/test/commands/explain.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import explainCommand from '../../src/commands/explain.js';
+
+const SAMPLE_SCAN = {
+  root: '/repo',
+  files: ['src/index.js', 'src/auth/login.js'],
+  packageMeta: { name: 'demo', dependencies: ['express'], devDependencies: [] },
+  frameworks: ['Express'],
+  orms: [],
+  routes: [{ method: 'POST', path: '/login', file: 'src/auth/login.js' }],
+  components: [],
+  models: [],
+};
+
+describe('draftwise explain', () => {
+  let dir;
+  let logs;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-explain-'));
+    await mkdir(join(dir, '.draftwise'));
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('errors if no flow name was given', async () => {
+    await expect(
+      explainCommand([], {
+        cwd: dir,
+        log: (m) => logs.push(m),
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/Missing flow name/);
+  });
+
+  it('errors if .draftwise/ is missing', async () => {
+    await rm(join(dir, '.draftwise'), { recursive: true });
+    await expect(
+      explainCommand(['login'], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/Run `draftwise init` first/);
+  });
+
+  it('joins multi-word flow args before slugifying', async () => {
+    await explainCommand(['user', 'signup'], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({ mode: 'agent' }),
+      complete: async () => 'unused',
+    });
+
+    const output = logs.join('\n');
+    expect(output).toContain('FLOW: user signup');
+    expect(output).toContain('user-signup.md');
+  });
+
+  it('agent mode: prints scanner data + flow + instruction without writing the snapshot', async () => {
+    await explainCommand(['login'], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({ mode: 'agent' }),
+      complete: async () => {
+        throw new Error('should not be called in agent mode');
+      },
+    });
+
+    const output = logs.join('\n');
+    expect(output).toContain('FLOW: login');
+    expect(output).toContain('SCANNER OUTPUT');
+    expect(output).toContain('Express');
+    expect(output).toContain('INSTRUCTION');
+
+    await expect(
+      readFile(join(dir, '.draftwise', 'flows', 'login.md')),
+    ).rejects.toThrow();
+  });
+
+  it('api mode: calls the model, prints the walkthrough, and writes the snapshot', async () => {
+    let captured;
+    await explainCommand(['login'], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+      }),
+      complete: async (req) => {
+        captured = req;
+        return '# Flow: login\n\nGenerated walkthrough.';
+      },
+    });
+
+    expect(captured.system).toContain('Draftwise');
+    expect(captured.prompt).toContain('"login"');
+    expect(captured.prompt).toContain('Express');
+
+    const saved = await readFile(
+      join(dir, '.draftwise', 'flows', 'login.md'),
+      'utf8',
+    );
+    expect(saved).toContain('# Flow: login');
+
+    expect(logs.join('\n')).toContain('# Flow: login');
+  });
+
+  it('errors when the scan returns zero files', async () => {
+    await expect(
+      explainCommand(['login'], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => ({ ...SAMPLE_SCAN, files: [] }),
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/No source files/);
+  });
+});

--- a/test/utils/slug.test.js
+++ b/test/utils/slug.test.js
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { slugify } from '../../src/utils/slug.js';
+
+describe('slugify', () => {
+  it('lowercases and dashifies words', () => {
+    expect(slugify('User Signup')).toBe('user-signup');
+  });
+
+  it('strips punctuation and quotes', () => {
+    expect(slugify('user "signup"!?')).toBe('user-signup');
+  });
+
+  it('collapses repeated separators', () => {
+    expect(slugify('a   b---c')).toBe('a-b-c');
+  });
+
+  it('returns "flow" when input has no usable characters', () => {
+    expect(slugify('!!!')).toBe('flow');
+  });
+
+  it('caps length at 60', () => {
+    const long = 'word '.repeat(50);
+    expect(slugify(long).length).toBeLessThanOrEqual(60);
+  });
+});


### PR DESCRIPTION
Traces a single flow through the codebase end-to-end. Same shape as scan: scanner output + AI prompt, with two execution modes. In api mode, calls the model, prints the walkthrough, and saves a snapshot to .draftwise/flows/<slug>.md. In agent mode, dumps scanner data + the flow name + an instruction for the host coding agent to consume.

Adds src/utils/slug.js for filesystem-safe flow slugs (multi-word flows join with dashes, junk/empty input falls back to "flow").

11 new tests across explain and slug. Smoke-tested locally: missing flow arg surfaces a usage hint, agent-mode prints scanner data without writing anything.