### PR TITLE
Implement draftwise new <idea> with conversational drafting

### DIFF
--- a/src/ai/prompts/new.js
+++ b/src/ai/prompts/new.js
@@ -1,0 +1,199 @@
+export const PLAN_SYSTEM = `You are Draftwise, a codebase-aware product spec drafting tool.
+
+A PM has proposed a new feature for a real codebase. Your job in this turn is NOT to write the spec yet. Your job is to plan the conversation that will lead to a good spec.
+
+You will receive: the PM's idea, the structured scanner output for the existing codebase. You will return ONE JSON object — no preamble, no prose around it, just the JSON inside a single fenced \`\`\`json block.
+
+The JSON has exactly this shape:
+
+{
+  "feature_slug": "kebab-case-feature-name (3-5 words max, derived from the idea)",
+  "feature_title": "human-readable title for the feature",
+  "affected_flows": [
+    { "name": "flow name (use existing names from the scanner if applicable)",
+      "files": ["concrete file paths from the scanner"],
+      "impact": "one sentence describing how this feature changes this flow" }
+  ],
+  "clarifying_questions": [
+    { "text": "the question, phrased the way you'd ask a PM",
+      "why": "what gap in your understanding this question fills — be specific to the codebase" }
+  ],
+  "adjacent_opportunities": [
+    { "flow": "name of an adjacent flow",
+      "suggestion": "what change to that flow could / should land alongside this feature",
+      "rationale": "why this matters — usually surfaces an edge case that would otherwise leak into review" }
+  ]
+}
+
+Hard rules:
+- ASK, DO NOT ASSUME. If something is unclear (target user, success metric, integration point, error handling, permissioning, payment, notifications), turn it into a clarifying_question. Never invent details to fill gaps.
+- Ground every affected_flow in real files from the scanner. If you can't see the affected flow in the scanner output, say so via a clarifying_question instead.
+- 4-8 clarifying questions. Specific to the codebase, not generic. Bad: "Who is the target user?". Good: "The scanner shows two user roles in src/auth/roles.ts — admin and member. Which of these (or a new role) gets access to this feature?".
+- 2-5 adjacent_opportunities. Each must point at a real existing flow the scanner detected. Skip the section if there are genuinely none.
+- Output JSON only. No markdown around it except the single fenced block.
+`;
+
+export function buildPlanPrompt({ idea, scan, packageMeta }) {
+  return [
+    `PM's idea: "${idea}"`,
+    '',
+    'Codebase scanner output (structured):',
+    '```json',
+    JSON.stringify(scan, null, 2),
+    '```',
+    '',
+    'Package metadata:',
+    '```json',
+    JSON.stringify(packageMeta, null, 2),
+    '```',
+    '',
+    'Return the conversation plan as JSON inside a single fenced ```json block, per the system instructions.',
+  ].join('\n');
+}
+
+export function parsePlanResponse(text) {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const raw = (fenced ? fenced[1] : text).trim();
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Could not parse the plan from the model response. ${err.message}\n\nResponse was:\n${text.slice(0, 500)}`,
+    );
+  }
+  if (!parsed.feature_slug || !Array.isArray(parsed.clarifying_questions)) {
+    throw new Error(
+      'Model response is missing required fields (feature_slug or clarifying_questions).',
+    );
+  }
+  return {
+    featureSlug: parsed.feature_slug,
+    featureTitle: parsed.feature_title ?? parsed.feature_slug,
+    affectedFlows: parsed.affected_flows ?? [],
+    clarifyingQuestions: parsed.clarifying_questions,
+    adjacentOpportunities: parsed.adjacent_opportunities ?? [],
+  };
+}
+
+export const SPEC_SYSTEM = `You are Draftwise, a codebase-aware product spec drafting tool.
+
+You have the PM's idea, the codebase scanner output, the PM's answers to clarifying questions, and the PM's accept/decline decisions on adjacent flow opportunities. Your job in this turn is to write the final product-spec.md.
+
+The spec is a markdown document with these sections, in order:
+
+# <Feature title>
+
+> One-sentence description of what this feature is.
+
+## Problem
+What's broken or missing today, with concrete evidence from the codebase or the PM's answers. No generic language.
+
+## Users
+Who this is for, drawn from the PM's answer about target users. Reference real user roles from the codebase if applicable.
+
+## User stories
+3-7 stories in "As a <user>, I want <action>, so that <outcome>" form.
+
+## Acceptance criteria
+Given/when/then bullets. Concrete, testable.
+
+## Affected flows
+For each flow this feature touches: name, files, what changes. Pull this directly from the affected_flows in the plan, refined by the PM's answers.
+
+## Adjacent changes
+For each adjacent_opportunity the PM accepted: include it here as a sibling change with rationale. Skip declined ones.
+
+## Edge cases
+Edge cases the PM surfaced in answers, plus any that fall out of the affected_flows analysis. Each one: what could go wrong, what should happen.
+
+## Test cases
+Product-level scenarios (not unit tests). Happy path + each edge case.
+
+## Scope
+Four sub-bullets:
+- **Covered:** what this spec includes
+- **Assumed:** what we're taking as given
+- **Hypothesized:** what we believe but haven't proven
+- **Out of scope:** what this spec explicitly excludes
+
+## Core metrics
+What success looks like. Measurable.
+
+## Counter metrics
+What could go wrong if we succeed too hard.
+
+Hard rules:
+- Reference real files, real routes, real models from the scanner. No inventing.
+- If a section has no content (e.g. no adjacent changes accepted), keep the heading but write "_None._" — don't fabricate.
+- Output the markdown only. No preamble. Start with the title.
+`;
+
+export function buildSpecPrompt({ idea, plan, scan, packageMeta, answers, opportunityDecisions }) {
+  const qa = plan.clarifyingQuestions.map((q, i) => ({
+    question: q.text,
+    answer: answers[i] ?? '',
+  }));
+  const opportunities = plan.adjacentOpportunities.map((o, i) => ({
+    flow: o.flow,
+    suggestion: o.suggestion,
+    rationale: o.rationale,
+    decision: opportunityDecisions[i] ?? 'declined',
+  }));
+
+  return [
+    `PM's idea: "${idea}"`,
+    `Feature slug: ${plan.featureSlug}`,
+    `Feature title: ${plan.featureTitle}`,
+    '',
+    'Affected flows (from scanner + plan):',
+    '```json',
+    JSON.stringify(plan.affectedFlows, null, 2),
+    '```',
+    '',
+    "PM's answers to clarifying questions:",
+    '```json',
+    JSON.stringify(qa, null, 2),
+    '```',
+    '',
+    "PM's decisions on adjacent opportunities:",
+    '```json',
+    JSON.stringify(opportunities, null, 2),
+    '```',
+    '',
+    'Codebase scanner output (for grounding references):',
+    '```json',
+    JSON.stringify(scan, null, 2),
+    '```',
+    '',
+    'Package metadata:',
+    '```json',
+    JSON.stringify(packageMeta, null, 2),
+    '```',
+    '',
+    'Write the full product-spec.md per the system instructions.',
+  ].join('\n');
+}
+
+export function buildAgentInstruction(idea) {
+  return `The PM has proposed: "${idea}".
+
+Use the scanner data above as ground truth for the existing codebase. Run a conversation with the PM in three phases:
+
+PHASE 1 — Plan the conversation (in your head, but share the plan with the PM):
+  - Identify which existing flows this feature affects, citing real file paths from the scanner.
+  - Draft 4-8 clarifying questions specific to the codebase (not generic). ASK, do not assume — every gap is a question.
+  - Identify 2-5 adjacent flow opportunities — places where a related change should land alongside this feature so edge cases don't get generated. Each must point at a real existing flow.
+
+PHASE 2 — Walk the PM through the questions and opportunities:
+  - Ask one clarifying question at a time. Wait for the answer.
+  - For each adjacent opportunity, present it and ask the PM to accept, decline, or defer.
+
+PHASE 3 — Generate product-spec.md:
+  - Use the PM's idea, scanner output, answers, and accept/decline decisions.
+  - Follow the section order: Problem, Users, User stories, Acceptance criteria, Affected flows, Adjacent changes, Edge cases, Test cases, Scope (covered/assumed/hypothesized/out of scope), Core metrics, Counter metrics.
+  - Reference real files/routes/models — do not invent.
+  - Save to .draftwise/specs/<feature-slug>/product-spec.md (create the directory if needed).
+
+Hard rules: ground every claim in the scanner; turn every gap into a question, not an assumption; keep the spec tight.`;
+}

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -1,0 +1,192 @@
+import { writeFile, mkdir, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { input, select } from '@inquirer/prompts';
+import { scan as defaultScan } from '../core/scanner.js';
+import { loadConfig as defaultLoadConfig } from '../utils/config.js';
+import { complete as defaultComplete } from '../ai/provider.js';
+import {
+  PLAN_SYSTEM,
+  SPEC_SYSTEM,
+  buildPlanPrompt,
+  parsePlanResponse,
+  buildSpecPrompt,
+  buildAgentInstruction,
+} from '../ai/prompts/new.js';
+import { slugify } from '../utils/slug.js';
+
+const DEFAULT_PROMPTS = {
+  askQuestion: ({ index, total, text, why }) =>
+    input({
+      message: `Q${index + 1}/${total} — ${text}\n  (why: ${why})\n  Your answer (or press enter to skip):`,
+    }),
+  decideOpportunity: ({ index, total, flow, suggestion, rationale }) =>
+    select({
+      message: `Opportunity ${index + 1}/${total} — adjacent change in "${flow}"\n  Suggestion: ${suggestion}\n  Why: ${rationale}\n  Decision:`,
+      choices: [
+        { name: 'Accept — include in this spec',     value: 'accepted' },
+        { name: 'Decline — keep it out',             value: 'declined' },
+        { name: 'Defer — note it but don\'t commit', value: 'deferred' },
+      ],
+      default: 'declined',
+    }),
+};
+
+async function pathExists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function compactScan(result) {
+  return {
+    frameworks: result.frameworks,
+    orms: result.orms,
+    routes: result.routes,
+    components: result.components.slice(0, 50),
+    models: result.models,
+    fileCount: result.files.length,
+    sampleFiles: result.files.slice(0, 30),
+  };
+}
+
+export default async function newCommand(args = [], deps = {}) {
+  const cwd = deps.cwd ?? process.cwd();
+  const log = deps.log ?? ((msg) => console.log(msg));
+  const scan = deps.scan ?? defaultScan;
+  const loadConfig = deps.loadConfig ?? defaultLoadConfig;
+  const complete = deps.complete ?? defaultComplete;
+  const prompts = { ...DEFAULT_PROMPTS, ...(deps.prompts ?? {}) };
+
+  const idea = args.join(' ').trim();
+  if (!idea) {
+    throw new Error(
+      'Missing idea. Usage: draftwise new "<your feature idea>"',
+    );
+  }
+
+  const draftwiseDir = join(cwd, '.draftwise');
+  if (!(await pathExists(draftwiseDir))) {
+    throw new Error('.draftwise/ not found. Run `draftwise init` first.');
+  }
+
+  const config = await loadConfig(cwd);
+
+  log(`Idea: "${idea}"`);
+  log('Scanning repo...');
+  const result = await scan(cwd);
+  if (!result.files || result.files.length === 0) {
+    throw new Error(
+      `No source files found under ${cwd}. Run \`draftwise new\` from your repo root.`,
+    );
+  }
+  const scanForPrompt = compactScan(result);
+
+  if (config.mode === 'agent') {
+    log('');
+    log('Agent mode — handing scanner data + the conversation plan off to your coding agent.');
+    log('');
+    log('---');
+    log(`IDEA: ${idea}`);
+    log('');
+    log('SCANNER OUTPUT');
+    log('```json');
+    log(JSON.stringify(scanForPrompt, null, 2));
+    log('```');
+    log('');
+    log('PACKAGE METADATA');
+    log('```json');
+    log(JSON.stringify(result.packageMeta, null, 2));
+    log('```');
+    log('');
+    log('INSTRUCTION');
+    log(buildAgentInstruction(idea));
+    return;
+  }
+
+  log(`API mode — calling ${config.provider} for the conversation plan...`);
+  const planText = await complete({
+    provider: config.provider,
+    apiKeyEnv: config.apiKeyEnv,
+    model: config.model,
+    system: PLAN_SYSTEM,
+    prompt: buildPlanPrompt({
+      idea,
+      scan: scanForPrompt,
+      packageMeta: result.packageMeta,
+    }),
+  });
+
+  const plan = parsePlanResponse(planText);
+  log('');
+  log(`Feature: ${plan.featureTitle} (slug: ${plan.featureSlug})`);
+  if (plan.affectedFlows.length > 0) {
+    log('');
+    log('Affected flows:');
+    for (const f of plan.affectedFlows) {
+      log(`  • ${f.name} — ${f.impact}`);
+      for (const file of f.files ?? []) log(`      ${file}`);
+    }
+  }
+  log('');
+  log(`Walking through ${plan.clarifyingQuestions.length} clarifying questions:`);
+  log('');
+
+  const answers = [];
+  for (let i = 0; i < plan.clarifyingQuestions.length; i++) {
+    const q = plan.clarifyingQuestions[i];
+    const answer = await prompts.askQuestion({
+      index: i,
+      total: plan.clarifyingQuestions.length,
+      text: q.text,
+      why: q.why,
+    });
+    answers.push(answer);
+  }
+
+  const opportunityDecisions = [];
+  if (plan.adjacentOpportunities.length > 0) {
+    log('');
+    log(`Pitching ${plan.adjacentOpportunities.length} adjacent opportunities:`);
+    log('');
+    for (let i = 0; i < plan.adjacentOpportunities.length; i++) {
+      const o = plan.adjacentOpportunities[i];
+      const decision = await prompts.decideOpportunity({
+        index: i,
+        total: plan.adjacentOpportunities.length,
+        flow: o.flow,
+        suggestion: o.suggestion,
+        rationale: o.rationale,
+      });
+      opportunityDecisions.push(decision);
+    }
+  }
+
+  log('');
+  log(`Synthesizing product-spec.md (${config.provider})...`);
+  const spec = await complete({
+    provider: config.provider,
+    apiKeyEnv: config.apiKeyEnv,
+    model: config.model,
+    system: SPEC_SYSTEM,
+    prompt: buildSpecPrompt({
+      idea,
+      plan,
+      scan: scanForPrompt,
+      packageMeta: result.packageMeta,
+      answers,
+      opportunityDecisions,
+    }),
+  });
+
+  const slug = slugify(plan.featureSlug);
+  const specDir = join(draftwiseDir, 'specs', slug);
+  await mkdir(specDir, { recursive: true });
+  await writeFile(join(specDir, 'product-spec.md'), spec, 'utf8');
+
+  log('');
+  log(`Wrote .draftwise/specs/${slug}/product-spec.md`);
+  log('Next: review, refine, then run `draftwise tech` to generate the technical spec.');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const COMMANDS = {
   init: () => import('./commands/init.js'),
   scan: () => import('./commands/scan.js'),
   explain: () => import('./commands/explain.js'),
+  new: () => import('./commands/new.js'),
 };
 
 const HELP = `draftwise — codebase-aware spec drafting
@@ -10,9 +11,10 @@ Usage:
   draftwise <command> [args]
 
 Commands:
-  init              Scan codebase and set up .draftwise/
-  scan              Refresh the codebase overview
-  explain <flow>    Trace how a specific flow works in the code
+  init                  Scan codebase and set up .draftwise/
+  scan                  Refresh the codebase overview
+  explain <flow>        Trace how a specific flow works in the code
+  new "<idea>"          Conversational drafting → product-spec.md
 
 Run "draftwise <command> --help" for command-specific help (coming soon).
 `;

--- a/test/ai/new.test.js
+++ b/test/ai/new.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { parsePlanResponse } from '../../src/ai/prompts/new.js';
+
+describe('parsePlanResponse', () => {
+  const valid = {
+    feature_slug: 'collab-albums',
+    feature_title: 'Collaborative Albums',
+    affected_flows: [
+      { name: 'album-create', files: ['src/api/albums.ts'], impact: 'now multi-user' },
+    ],
+    clarifying_questions: [
+      { text: 'Who can invite?', why: 'permissions are unclear from the scanner' },
+    ],
+    adjacent_opportunities: [
+      { flow: 'sharing', suggestion: 'unify share + invite', rationale: 'avoids drift' },
+    ],
+  };
+
+  it('parses a fenced ```json block', () => {
+    const text = 'preamble\n```json\n' + JSON.stringify(valid) + '\n```\nepilogue';
+    const out = parsePlanResponse(text);
+    expect(out.featureSlug).toBe('collab-albums');
+    expect(out.featureTitle).toBe('Collaborative Albums');
+    expect(out.clarifyingQuestions).toHaveLength(1);
+    expect(out.affectedFlows[0].files[0]).toBe('src/api/albums.ts');
+    expect(out.adjacentOpportunities[0].flow).toBe('sharing');
+  });
+
+  it('parses raw JSON without a code fence', () => {
+    const out = parsePlanResponse(JSON.stringify(valid));
+    expect(out.featureSlug).toBe('collab-albums');
+  });
+
+  it('defaults missing arrays to empty', () => {
+    const out = parsePlanResponse(
+      JSON.stringify({
+        feature_slug: 'x',
+        feature_title: 'X',
+        clarifying_questions: [],
+      }),
+    );
+    expect(out.affectedFlows).toEqual([]);
+    expect(out.adjacentOpportunities).toEqual([]);
+  });
+
+  it('throws when JSON is malformed', () => {
+    expect(() => parsePlanResponse('not json at all')).toThrow(
+      /Could not parse the plan/,
+    );
+  });
+
+  it('throws when required fields are missing', () => {
+    expect(() => parsePlanResponse(JSON.stringify({}))).toThrow(
+      /missing required fields/,
+    );
+  });
+});

--- a/test/commands/new.test.js
+++ b/test/commands/new.test.js
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import newCommand from '../../src/commands/new.js';
+
+const SAMPLE_SCAN = {
+  root: '/repo',
+  files: ['src/api/albums.ts', 'src/components/AlbumGrid.tsx'],
+  packageMeta: {
+    name: 'photos',
+    dependencies: ['next', '@prisma/client'],
+    devDependencies: [],
+  },
+  frameworks: ['Next.js'],
+  orms: ['Prisma'],
+  routes: [{ method: 'GET', path: '/albums', file: 'src/api/albums.ts' }],
+  components: [{ name: 'AlbumGrid', file: 'src/components/AlbumGrid.tsx' }],
+  models: [{ name: 'Album', file: 'prisma/schema.prisma', fields: ['id', 'title'] }],
+};
+
+const SAMPLE_PLAN = {
+  feature_slug: 'collab-albums',
+  feature_title: 'Collaborative Albums',
+  affected_flows: [
+    {
+      name: 'album-create',
+      files: ['src/api/albums.ts'],
+      impact: 'now accepts collaborator IDs',
+    },
+  ],
+  clarifying_questions: [
+    { text: 'Who can invite?', why: 'permissions are unclear' },
+    { text: 'Notification on invite?', why: 'no notification system in scanner' },
+  ],
+  adjacent_opportunities: [
+    {
+      flow: 'sharing',
+      suggestion: 'unify share + invite',
+      rationale: 'avoid drift',
+    },
+  ],
+};
+
+function fakePrompts({ answers, decisions }) {
+  let qIndex = 0;
+  let dIndex = 0;
+  return {
+    askQuestion: async () => answers[qIndex++],
+    decideOpportunity: async () => decisions[dIndex++],
+  };
+}
+
+describe('draftwise new', () => {
+  let dir;
+  let logs;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-new-'));
+    await mkdir(join(dir, '.draftwise'));
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('errors if no idea was given', async () => {
+    await expect(
+      newCommand([], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/Missing idea/);
+  });
+
+  it('errors if .draftwise/ is missing', async () => {
+    await rm(join(dir, '.draftwise'), { recursive: true });
+    await expect(
+      newCommand(['add', 'collaborative', 'albums'], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/Run `draftwise init` first/);
+  });
+
+  it('agent mode dumps scanner data + idea + 3-phase instruction without writing the spec', async () => {
+    await newCommand(['add', 'collab', 'albums'], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({ mode: 'agent' }),
+      complete: async () => {
+        throw new Error('should not be called in agent mode');
+      },
+    });
+
+    const output = logs.join('\n');
+    expect(output).toContain('IDEA: add collab albums');
+    expect(output).toContain('SCANNER OUTPUT');
+    expect(output).toContain('PHASE 1');
+    expect(output).toContain('PHASE 2');
+    expect(output).toContain('PHASE 3');
+
+    await expect(
+      readFile(join(dir, '.draftwise', 'specs', 'collab-albums', 'product-spec.md')),
+    ).rejects.toThrow();
+  });
+
+  it('api mode walks the user through Q&A then writes the spec', async () => {
+    let callCount = 0;
+    const captured = [];
+    await newCommand(['add', 'collab', 'albums'], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+      }),
+      complete: async (req) => {
+        callCount++;
+        captured.push(req);
+        if (callCount === 1) {
+          return '```json\n' + JSON.stringify(SAMPLE_PLAN) + '\n```';
+        }
+        return '# Collaborative Albums\n\nFinal spec body.';
+      },
+      prompts: fakePrompts({
+        answers: ['Anyone in the album', 'Yes — email + in-app'],
+        decisions: ['accepted'],
+      }),
+    });
+
+    expect(callCount).toBe(2);
+    expect(captured[0].system).toContain('plan the conversation');
+    expect(captured[1].system).toContain('product-spec.md');
+    expect(captured[1].prompt).toContain('Anyone in the album');
+    expect(captured[1].prompt).toContain('"decision": "accepted"');
+
+    const spec = await readFile(
+      join(dir, '.draftwise', 'specs', 'collab-albums', 'product-spec.md'),
+      'utf8',
+    );
+    expect(spec).toContain('# Collaborative Albums');
+  });
+
+  it('api mode handles plans with no adjacent opportunities', async () => {
+    const planWithoutOpportunities = {
+      ...SAMPLE_PLAN,
+      adjacent_opportunities: [],
+    };
+
+    let callCount = 0;
+    await newCommand(['idea'], {
+      cwd: dir,
+      log: () => {},
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+      }),
+      complete: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return JSON.stringify(planWithoutOpportunities);
+        }
+        return '# Spec\n';
+      },
+      prompts: fakePrompts({
+        answers: ['', ''],
+        decisions: [],
+      }),
+    });
+
+    expect(callCount).toBe(2);
+    const spec = await readFile(
+      join(dir, '.draftwise', 'specs', 'collab-albums', 'product-spec.md'),
+      'utf8',
+    );
+    expect(spec).toContain('# Spec');
+  });
+});


### PR DESCRIPTION
Three-phase command, per CLAUDE.md's "conversation > form-filling" principle:

Phase 1 — plan call. The model returns a JSON plan with affected flows (grounded in real scanner files), 4-8 clarifying questions each tied to a specific gap in the codebase, and 2-5 adjacent opportunities pointing at existing flows that should change alongside the feature so edge cases surface during drafting, not in code review.

Phase 2 — interactive loop. Inquirer walks the PM through each question (free-text answers, "I don't know" allowed) and each opportunity (accept / decline / defer).

Phase 3 — synthesis call. Idea + scanner + answers + decisions → product-spec.md following the template (problem, users, stories, acceptance criteria, affected flows, adjacent changes, edge cases, test cases, scope, metrics, counter-metrics). Saves to .draftwise/specs/<feature-slug>/product-spec.md.

Agent mode bundles all three phases into one instruction for the host coding agent. Hard rule shared across both modes: ASK, don't assume — every gap becomes a question, never an invention.

10 new tests covering parser robustness (fenced/raw/missing fields) and command flow (both modes, no-opportunities edge case, missing inputs).