### PR TITLE
Implement draftwise tech [<feature>]

### DIFF
--- a/src/ai/prompts/tech.js
+++ b/src/ai/prompts/tech.js
@@ -1,0 +1,75 @@
+export const SYSTEM = `You are Draftwise, a codebase-aware tool that drafts technical specs from approved product specs.
+
+You will receive: an approved product-spec.md (already through the conversational drafting phase, so it's grounded in reality), and the structured scanner output for the existing codebase. Your job is to write the technical-spec.md — the engineering counterpart that translates intent into concrete code changes.
+
+The technical spec has these sections, in order:
+
+# <Feature title> — Technical spec
+
+> One-sentence framing that links to the product spec ("Implements the feature described in product-spec.md").
+
+## Summary
+2-4 sentences. What's being built, where it lands in the existing architecture, and the broad shape of the change.
+
+## Data model changes
+For each model change: model name, file (the real schema file from the scanner — e.g. prisma/schema.prisma or the Mongoose model file), the specific field(s) added/modified/removed, and the migration approach. If no schema changes, write "_None._".
+
+## API changes
+For each endpoint: method + path, file (the real route file from the scanner), what changes (new endpoint, modified handler, deprecated). If no API changes, write "_None._".
+
+## Component changes
+For each UI component: component name, file (real path from the scanner), what changes (new file, modified, removed). If no UI changes, write "_None._".
+
+## Migration notes
+Deployment ordering, backfill steps, feature flags, rollout plan. If trivial, write "_None — ship it._".
+
+## Test plan
+Unit, integration, and end-to-end coverage. Tie back to the acceptance criteria from the product spec.
+
+## Open technical questions
+Specific questions the engineer should resolve before starting. Each grounded in something concrete from the scanner output. If genuinely none, write "_None._".
+
+Hard rules:
+- Every file path must be a real path from the scanner output. If the product spec describes a change to a system that the scanner doesn't surface, raise it under "Open technical questions" — do NOT invent file paths.
+- Match the codebase's existing conventions. If the scanner shows Prisma, propose schema changes in Prisma syntax. If it shows Express, propose handler signatures matching Express. Don't impose foreign patterns.
+- Keep it tight. Engineers stop reading verbose specs.
+- Output the markdown only. No preamble. Start with the title.
+`;
+
+export function buildPrompt({ productSpec, scan, packageMeta }) {
+  return [
+    'Approved product spec (read this carefully — it is the source of intent):',
+    '',
+    productSpec,
+    '',
+    '---',
+    '',
+    'Codebase scanner output (the source of truth for existing code):',
+    '```json',
+    JSON.stringify(scan, null, 2),
+    '```',
+    '',
+    'Package metadata:',
+    '```json',
+    JSON.stringify(packageMeta, null, 2),
+    '```',
+    '',
+    'Write the technical spec per the system instructions.',
+  ].join('\n');
+}
+
+export function buildAgentInstruction(slug) {
+  return `The product spec above is approved. Use the scanner data as ground truth for the existing codebase. Generate the technical-spec.md following the section structure below, grounded in real files/routes/models from the scanner. Save it to .draftwise/specs/${slug}/technical-spec.md.
+
+Sections in order:
+- Title + one-sentence framing
+- Summary
+- Data model changes (cite real schema files; "_None._" if none)
+- API changes (cite real route files; "_None._" if none)
+- Component changes (cite real component files; "_None._" if none)
+- Migration notes
+- Test plan (tie to acceptance criteria)
+- Open technical questions
+
+Hard rule: never invent file paths or routes. If the product spec implies a change the scanner doesn't surface, list it under Open technical questions instead of fabricating a path.`;
+}

--- a/src/commands/tech.js
+++ b/src/commands/tech.js
@@ -1,0 +1,141 @@
+import { readFile, writeFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { select } from '@inquirer/prompts';
+import { scan as defaultScan } from '../core/scanner.js';
+import { loadConfig as defaultLoadConfig } from '../utils/config.js';
+import { complete as defaultComplete } from '../ai/provider.js';
+import { listSpecs as defaultListSpecs } from '../utils/specs.js';
+import { SYSTEM, buildPrompt, buildAgentInstruction } from '../ai/prompts/tech.js';
+
+const DEFAULT_PROMPTS = {
+  pickSpec: ({ specs }) =>
+    select({
+      message: 'Which feature spec do you want a technical spec for?',
+      choices: specs.map((s) => ({
+        name: s.hasTechnicalSpec ? `${s.slug}  (technical-spec.md exists — will overwrite)` : s.slug,
+        value: s.slug,
+      })),
+    }),
+};
+
+async function pathExists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function compactScan(result) {
+  return {
+    frameworks: result.frameworks,
+    orms: result.orms,
+    routes: result.routes,
+    components: result.components.slice(0, 50),
+    models: result.models,
+    fileCount: result.files.length,
+    sampleFiles: result.files.slice(0, 30),
+  };
+}
+
+export default async function techCommand(args = [], deps = {}) {
+  const cwd = deps.cwd ?? process.cwd();
+  const log = deps.log ?? ((msg) => console.log(msg));
+  const scan = deps.scan ?? defaultScan;
+  const loadConfig = deps.loadConfig ?? defaultLoadConfig;
+  const complete = deps.complete ?? defaultComplete;
+  const listSpecs = deps.listSpecs ?? defaultListSpecs;
+  const prompts = { ...DEFAULT_PROMPTS, ...(deps.prompts ?? {}) };
+
+  const draftwiseDir = join(cwd, '.draftwise');
+  if (!(await pathExists(draftwiseDir))) {
+    throw new Error('.draftwise/ not found. Run `draftwise init` first.');
+  }
+
+  const config = await loadConfig(cwd);
+  const requestedSlug = args[0];
+
+  const specs = (await listSpecs(cwd)).filter((s) => s.hasProductSpec);
+  if (specs.length === 0) {
+    throw new Error(
+      'No product specs found in .draftwise/specs/. Run `draftwise new "<idea>"` first.',
+    );
+  }
+
+  let target;
+  if (requestedSlug) {
+    target = specs.find((s) => s.slug === requestedSlug);
+    if (!target) {
+      const available = specs.map((s) => s.slug).join(', ');
+      throw new Error(
+        `No product spec found for "${requestedSlug}". Available: ${available}`,
+      );
+    }
+  } else if (specs.length === 1) {
+    target = specs[0];
+    log(`Using the only product spec: ${target.slug}`);
+  } else {
+    const slug = await prompts.pickSpec({ specs });
+    target = specs.find((s) => s.slug === slug);
+  }
+
+  const productSpec = await readFile(target.productSpec, 'utf8');
+  if (!productSpec.trim()) {
+    throw new Error(
+      `${target.slug}/product-spec.md is empty. Run \`draftwise new\` to populate it.`,
+    );
+  }
+
+  log('Scanning repo...');
+  const result = await scan(cwd);
+  if (!result.files || result.files.length === 0) {
+    throw new Error(
+      `No source files found under ${cwd}. Run \`draftwise tech\` from your repo root.`,
+    );
+  }
+  const scanForPrompt = compactScan(result);
+
+  if (config.mode === 'agent') {
+    log('');
+    log('Agent mode — handing scanner data + product spec off to your coding agent.');
+    log('');
+    log('---');
+    log(`SPEC: ${target.slug}`);
+    log('');
+    log('PRODUCT SPEC');
+    log(productSpec);
+    log('');
+    log('SCANNER OUTPUT');
+    log('```json');
+    log(JSON.stringify(scanForPrompt, null, 2));
+    log('```');
+    log('');
+    log('PACKAGE METADATA');
+    log('```json');
+    log(JSON.stringify(result.packageMeta, null, 2));
+    log('```');
+    log('');
+    log('INSTRUCTION');
+    log(buildAgentInstruction(target.slug));
+    return;
+  }
+
+  log(`API mode — calling ${config.provider}...`);
+  const techSpec = await complete({
+    provider: config.provider,
+    apiKeyEnv: config.apiKeyEnv,
+    model: config.model,
+    system: SYSTEM,
+    prompt: buildPrompt({
+      productSpec,
+      scan: scanForPrompt,
+      packageMeta: result.packageMeta,
+    }),
+  });
+
+  await writeFile(target.technicalSpec, techSpec, 'utf8');
+  log('');
+  log(`Wrote .draftwise/specs/${target.slug}/technical-spec.md`);
+  log('Next: review, refine, then run `draftwise tasks` to break it into work items.');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ const COMMANDS = {
   scan: () => import('./commands/scan.js'),
   explain: () => import('./commands/explain.js'),
   new: () => import('./commands/new.js'),
+  tech: () => import('./commands/tech.js'),
 };
 
 const HELP = `draftwise — codebase-aware spec drafting
@@ -15,6 +16,7 @@ Commands:
   scan                  Refresh the codebase overview
   explain <flow>        Trace how a specific flow works in the code
   new "<idea>"          Conversational drafting → product-spec.md
+  tech [<feature>]      Draft technical-spec.md from approved product spec
 
 Run "draftwise <command> --help" for command-specific help (coming soon).
 `;

--- a/src/utils/specs.js
+++ b/src/utils/specs.js
@@ -1,0 +1,41 @@
+import { readdir, access } from 'node:fs/promises';
+import { join } from 'node:path';
+
+async function pathExists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function listSpecs(cwd) {
+  const specsDir = join(cwd, '.draftwise', 'specs');
+  let entries;
+  try {
+    entries = await readdir(specsDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const dir = join(specsDir, entry.name);
+    const productSpec = join(dir, 'product-spec.md');
+    const technicalSpec = join(dir, 'technical-spec.md');
+    const tasks = join(dir, 'tasks.md');
+    out.push({
+      slug: entry.name,
+      dir,
+      productSpec,
+      technicalSpec,
+      tasks,
+      hasProductSpec: await pathExists(productSpec),
+      hasTechnicalSpec: await pathExists(technicalSpec),
+      hasTasks: await pathExists(tasks),
+    });
+  }
+  out.sort((a, b) => a.slug.localeCompare(b.slug));
+  return out;
+}

--- a/test/commands/tech.test.js
+++ b/test/commands/tech.test.js
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import techCommand from '../../src/commands/tech.js';
+
+const SAMPLE_SCAN = {
+  root: '/repo',
+  files: ['src/api/albums.ts'],
+  packageMeta: { name: 'photos', dependencies: ['next'], devDependencies: [] },
+  frameworks: ['Next.js'],
+  orms: ['Prisma'],
+  routes: [{ method: 'GET', path: '/albums', file: 'src/api/albums.ts' }],
+  components: [],
+  models: [{ name: 'Album', file: 'prisma/schema.prisma', fields: ['id', 'title'] }],
+};
+
+async function seedSpec(dir, slug, productBody = '# Product Spec\n\nBody.') {
+  const specDir = join(dir, '.draftwise', 'specs', slug);
+  await mkdir(specDir, { recursive: true });
+  await writeFile(join(specDir, 'product-spec.md'), productBody, 'utf8');
+  return specDir;
+}
+
+describe('draftwise tech', () => {
+  let dir;
+  let logs;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-tech-'));
+    await mkdir(join(dir, '.draftwise'));
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('errors if .draftwise/ is missing', async () => {
+    await rm(join(dir, '.draftwise'), { recursive: true });
+    await expect(
+      techCommand([], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/Run `draftwise init` first/);
+  });
+
+  it('errors if there are no product specs yet', async () => {
+    await expect(
+      techCommand([], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/No product specs found/);
+  });
+
+  it('auto-picks the only spec when there is exactly one', async () => {
+    await seedSpec(dir, 'collab-albums');
+    let captured;
+    await techCommand([], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+      }),
+      complete: async (req) => {
+        captured = req;
+        return '# Tech\n\nWritten.';
+      },
+    });
+
+    expect(logs.join('\n')).toContain('Using the only product spec: collab-albums');
+    expect(captured.system).toContain('technical-spec.md');
+    expect(captured.prompt).toContain('# Product Spec');
+
+    const tech = await readFile(
+      join(dir, '.draftwise', 'specs', 'collab-albums', 'technical-spec.md'),
+      'utf8',
+    );
+    expect(tech).toBe('# Tech\n\nWritten.');
+  });
+
+  it('uses the slug arg to pick a specific spec when given', async () => {
+    await seedSpec(dir, 'alpha');
+    await seedSpec(dir, 'beta');
+
+    await techCommand(['beta'], {
+      cwd: dir,
+      log: () => {},
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+      }),
+      complete: async () => '# Beta tech',
+    });
+
+    const tech = await readFile(
+      join(dir, '.draftwise', 'specs', 'beta', 'technical-spec.md'),
+      'utf8',
+    );
+    expect(tech).toBe('# Beta tech');
+
+    await expect(
+      readFile(join(dir, '.draftwise', 'specs', 'alpha', 'technical-spec.md')),
+    ).rejects.toThrow();
+  });
+
+  it('errors when an unknown slug is requested', async () => {
+    await seedSpec(dir, 'alpha');
+
+    await expect(
+      techCommand(['ghost'], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/No product spec found for "ghost"/);
+  });
+
+  it('prompts the user when there are multiple specs and no slug arg', async () => {
+    await seedSpec(dir, 'alpha');
+    await seedSpec(dir, 'beta');
+
+    await techCommand([], {
+      cwd: dir,
+      log: () => {},
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+      }),
+      complete: async () => '# Beta tech',
+      prompts: { pickSpec: async () => 'beta' },
+    });
+
+    const tech = await readFile(
+      join(dir, '.draftwise', 'specs', 'beta', 'technical-spec.md'),
+      'utf8',
+    );
+    expect(tech).toBe('# Beta tech');
+  });
+
+  it('agent mode dumps product spec + scanner + instruction without writing', async () => {
+    await seedSpec(dir, 'collab-albums', '# Product\n\nThe spec.');
+
+    await techCommand([], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({ mode: 'agent' }),
+      complete: async () => {
+        throw new Error('should not be called in agent mode');
+      },
+    });
+
+    const output = logs.join('\n');
+    expect(output).toContain('SPEC: collab-albums');
+    expect(output).toContain('PRODUCT SPEC');
+    expect(output).toContain('# Product');
+    expect(output).toContain('SCANNER OUTPUT');
+    expect(output).toContain('INSTRUCTION');
+
+    await expect(
+      readFile(join(dir, '.draftwise', 'specs', 'collab-albums', 'technical-spec.md')),
+    ).rejects.toThrow();
+  });
+
+  it('errors if the product spec is empty', async () => {
+    await seedSpec(dir, 'empty', '');
+
+    await expect(
+      techCommand([], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/empty/);
+  });
+});

--- a/test/utils/specs.test.js
+++ b/test/utils/specs.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { listSpecs } from '../../src/utils/specs.js';
+
+describe('listSpecs', () => {
+  let dir;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-specs-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('returns empty when .draftwise/specs is missing', async () => {
+    expect(await listSpecs(dir)).toEqual([]);
+  });
+
+  it('returns empty when specs/ exists but is empty', async () => {
+    await mkdir(join(dir, '.draftwise', 'specs'), { recursive: true });
+    expect(await listSpecs(dir)).toEqual([]);
+  });
+
+  it('lists specs and reports which files exist', async () => {
+    const specsDir = join(dir, '.draftwise', 'specs');
+    await mkdir(join(specsDir, 'alpha'), { recursive: true });
+    await writeFile(join(specsDir, 'alpha', 'product-spec.md'), '# alpha', 'utf8');
+    await writeFile(join(specsDir, 'alpha', 'technical-spec.md'), '# tech', 'utf8');
+
+    await mkdir(join(specsDir, 'beta'), { recursive: true });
+    await writeFile(join(specsDir, 'beta', 'product-spec.md'), '# beta', 'utf8');
+
+    const specs = await listSpecs(dir);
+    expect(specs.map((s) => s.slug)).toEqual(['alpha', 'beta']);
+    expect(specs[0].hasProductSpec).toBe(true);
+    expect(specs[0].hasTechnicalSpec).toBe(true);
+    expect(specs[1].hasProductSpec).toBe(true);
+    expect(specs[1].hasTechnicalSpec).toBe(false);
+  });
+});


### PR DESCRIPTION
Reads an approved product-spec.md and drafts technical-spec.md grounded in the scanner output. Sections: summary, data model changes, API changes, component changes, migration notes, test plan, open technical questions. Hard rule shared with new and explain: every cited file path must come from the scanner — if a product-spec implication isn't visible in the codebase, it surfaces as an open question rather than a fabricated path.

Spec selection mirrors common CLI ergonomics: pass a slug (`draftwise tech collab-albums`) to target one directly, auto-pick when there's exactly one product spec, or fall back to an inquirer select when multiple specs coexist. Existing technical-spec.md is overwritten — flagged in the picker so the user knows.

Adds src/utils/specs.js (listSpecs) which tasks/list/show will reuse. 11 new tests cover the helper, command flow in both modes, and the four selection paths (auto / arg / unknown-arg / multi-spec prompt) plus the empty-product-spec error.