### PR TITLE
Implement draftwise tasks [<feature>]

### DIFF
--- a/src/ai/prompts/tasks.js
+++ b/src/ai/prompts/tasks.js
@@ -1,0 +1,74 @@
+export const SYSTEM = `You are Draftwise, a codebase-aware tool that breaks technical specs into ordered implementation tasks.
+
+You will receive: an approved technical-spec.md (already grounded in the real codebase) and the structured scanner output. Your job is to write tasks.md — an ordered breakdown an engineer can pick up and ship from.
+
+The tasks document has these sections, in order:
+
+# <Feature title> — Tasks
+
+> One-sentence framing.
+
+## Overview
+2-3 sentences summarizing the work — total task count, broad shape (e.g. "schema first, then API, then UI"), notable parallel tracks.
+
+## Tasks
+A numbered list of tasks. Each task is one logical unit of work — small enough to land in one PR, large enough to be worth a checkbox. Format each as:
+
+\`\`\`
+### N. <task title>
+- **Goal:** one sentence on what this task accomplishes
+- **Files:** comma-separated real file paths from the technical spec / scanner; for new files, mark "(new)"
+- **Depends on:** a list of task numbers this one needs first, or "none"
+- **Parallel with:** a list of task numbers that can run in parallel with this one (no dependency either way), or "none"
+- **Acceptance:** what "done" looks like, tied to the technical spec / acceptance criteria
+\`\`\`
+
+Order the tasks so each one's dependencies appear before it. Don't sort alphabetically.
+
+## Suggested execution order
+A short paragraph or bullets describing the dependency chain — which task to start with, where things can fan out into parallel tracks, where they merge back.
+
+## Open questions
+Things the engineer must resolve before or during execution that aren't pinned down by the technical spec. If the technical spec is fully resolved, write "_None._".
+
+Hard rules:
+- File paths must be real paths from the technical spec or scanner output. Mark new files explicitly with "(new)" rather than inventing existing-looking paths.
+- Don't pad. If the work is genuinely small, three tasks is fine. If it's large, twenty is fine. Don't manufacture tasks for the sake of structure.
+- Each "Depends on" link must point at a task number that exists in this document.
+- Output the markdown only. No preamble. Start with the title.
+`;
+
+export function buildPrompt({ technicalSpec, scan, packageMeta }) {
+  return [
+    'Approved technical spec (read carefully — it defines the work):',
+    '',
+    technicalSpec,
+    '',
+    '---',
+    '',
+    'Codebase scanner output (the source of truth for existing code):',
+    '```json',
+    JSON.stringify(scan, null, 2),
+    '```',
+    '',
+    'Package metadata:',
+    '```json',
+    JSON.stringify(packageMeta, null, 2),
+    '```',
+    '',
+    'Write tasks.md per the system instructions.',
+  ].join('\n');
+}
+
+export function buildAgentInstruction(slug) {
+  return `The technical spec above is approved. Use the scanner data as ground truth. Generate tasks.md following the section structure below, ordered so each task's dependencies appear before it. Save it to .draftwise/specs/${slug}/tasks.md.
+
+Sections in order:
+- Title + one-sentence framing
+- Overview (2-3 sentences, total count + broad shape)
+- Tasks (numbered, each with: Goal, Files, Depends on, Parallel with, Acceptance)
+- Suggested execution order
+- Open questions
+
+Hard rules: real file paths only (mark new files "(new)"), don't pad with fluff tasks, each "Depends on" must point at a task number you've actually defined.`;
+}

--- a/src/commands/tasks.js
+++ b/src/commands/tasks.js
@@ -1,0 +1,141 @@
+import { readFile, writeFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { select } from '@inquirer/prompts';
+import { scan as defaultScan } from '../core/scanner.js';
+import { loadConfig as defaultLoadConfig } from '../utils/config.js';
+import { complete as defaultComplete } from '../ai/provider.js';
+import { listSpecs as defaultListSpecs } from '../utils/specs.js';
+import { SYSTEM, buildPrompt, buildAgentInstruction } from '../ai/prompts/tasks.js';
+
+const DEFAULT_PROMPTS = {
+  pickSpec: ({ specs }) =>
+    select({
+      message: 'Which feature do you want a task breakdown for?',
+      choices: specs.map((s) => ({
+        name: s.hasTasks ? `${s.slug}  (tasks.md exists — will overwrite)` : s.slug,
+        value: s.slug,
+      })),
+    }),
+};
+
+async function pathExists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function compactScan(result) {
+  return {
+    frameworks: result.frameworks,
+    orms: result.orms,
+    routes: result.routes,
+    components: result.components.slice(0, 50),
+    models: result.models,
+    fileCount: result.files.length,
+    sampleFiles: result.files.slice(0, 30),
+  };
+}
+
+export default async function tasksCommand(args = [], deps = {}) {
+  const cwd = deps.cwd ?? process.cwd();
+  const log = deps.log ?? ((msg) => console.log(msg));
+  const scan = deps.scan ?? defaultScan;
+  const loadConfig = deps.loadConfig ?? defaultLoadConfig;
+  const complete = deps.complete ?? defaultComplete;
+  const listSpecs = deps.listSpecs ?? defaultListSpecs;
+  const prompts = { ...DEFAULT_PROMPTS, ...(deps.prompts ?? {}) };
+
+  const draftwiseDir = join(cwd, '.draftwise');
+  if (!(await pathExists(draftwiseDir))) {
+    throw new Error('.draftwise/ not found. Run `draftwise init` first.');
+  }
+
+  const config = await loadConfig(cwd);
+  const requestedSlug = args[0];
+
+  const specs = (await listSpecs(cwd)).filter((s) => s.hasTechnicalSpec);
+  if (specs.length === 0) {
+    throw new Error(
+      'No technical specs found in .draftwise/specs/. Run `draftwise tech` first.',
+    );
+  }
+
+  let target;
+  if (requestedSlug) {
+    target = specs.find((s) => s.slug === requestedSlug);
+    if (!target) {
+      const available = specs.map((s) => s.slug).join(', ');
+      throw new Error(
+        `No technical spec found for "${requestedSlug}". Available: ${available}`,
+      );
+    }
+  } else if (specs.length === 1) {
+    target = specs[0];
+    log(`Using the only technical spec: ${target.slug}`);
+  } else {
+    const slug = await prompts.pickSpec({ specs });
+    target = specs.find((s) => s.slug === slug);
+  }
+
+  const technicalSpec = await readFile(target.technicalSpec, 'utf8');
+  if (!technicalSpec.trim()) {
+    throw new Error(
+      `${target.slug}/technical-spec.md is empty. Run \`draftwise tech\` to populate it.`,
+    );
+  }
+
+  log('Scanning repo...');
+  const result = await scan(cwd);
+  if (!result.files || result.files.length === 0) {
+    throw new Error(
+      `No source files found under ${cwd}. Run \`draftwise tasks\` from your repo root.`,
+    );
+  }
+  const scanForPrompt = compactScan(result);
+
+  if (config.mode === 'agent') {
+    log('');
+    log('Agent mode — handing scanner data + technical spec off to your coding agent.');
+    log('');
+    log('---');
+    log(`SPEC: ${target.slug}`);
+    log('');
+    log('TECHNICAL SPEC');
+    log(technicalSpec);
+    log('');
+    log('SCANNER OUTPUT');
+    log('```json');
+    log(JSON.stringify(scanForPrompt, null, 2));
+    log('```');
+    log('');
+    log('PACKAGE METADATA');
+    log('```json');
+    log(JSON.stringify(result.packageMeta, null, 2));
+    log('```');
+    log('');
+    log('INSTRUCTION');
+    log(buildAgentInstruction(target.slug));
+    return;
+  }
+
+  log(`API mode — calling ${config.provider}...`);
+  const tasks = await complete({
+    provider: config.provider,
+    apiKeyEnv: config.apiKeyEnv,
+    model: config.model,
+    system: SYSTEM,
+    prompt: buildPrompt({
+      technicalSpec,
+      scan: scanForPrompt,
+      packageMeta: result.packageMeta,
+    }),
+  });
+
+  await writeFile(target.tasks, tasks, 'utf8');
+  log('');
+  log(`Wrote .draftwise/specs/${target.slug}/tasks.md`);
+  log('Next: pick the first task with no dependencies and start shipping.');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const COMMANDS = {
   explain: () => import('./commands/explain.js'),
   new: () => import('./commands/new.js'),
   tech: () => import('./commands/tech.js'),
+  tasks: () => import('./commands/tasks.js'),
 };
 
 const HELP = `draftwise — codebase-aware spec drafting
@@ -17,6 +18,7 @@ Commands:
   explain <flow>        Trace how a specific flow works in the code
   new "<idea>"          Conversational drafting → product-spec.md
   tech [<feature>]      Draft technical-spec.md from approved product spec
+  tasks [<feature>]     Generate ordered tasks.md from technical spec
 
 Run "draftwise <command> --help" for command-specific help (coming soon).
 `;

--- a/test/commands/tasks.test.js
+++ b/test/commands/tasks.test.js
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import tasksCommand from '../../src/commands/tasks.js';
+
+const SAMPLE_SCAN = {
+  root: '/repo',
+  files: ['src/api/albums.ts'],
+  packageMeta: { name: 'photos', dependencies: ['next'], devDependencies: [] },
+  frameworks: ['Next.js'],
+  orms: ['Prisma'],
+  routes: [{ method: 'GET', path: '/albums', file: 'src/api/albums.ts' }],
+  components: [],
+  models: [{ name: 'Album', file: 'prisma/schema.prisma', fields: ['id', 'title'] }],
+};
+
+async function seedSpec(dir, slug, opts = {}) {
+  const specDir = join(dir, '.draftwise', 'specs', slug);
+  await mkdir(specDir, { recursive: true });
+  await writeFile(
+    join(specDir, 'product-spec.md'),
+    opts.product ?? '# Product\n',
+    'utf8',
+  );
+  if (opts.technical !== null) {
+    await writeFile(
+      join(specDir, 'technical-spec.md'),
+      opts.technical ?? '# Tech\n\nBody.',
+      'utf8',
+    );
+  }
+  return specDir;
+}
+
+describe('draftwise tasks', () => {
+  let dir;
+  let logs;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-tasks-'));
+    await mkdir(join(dir, '.draftwise'));
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('errors if .draftwise/ is missing', async () => {
+    await rm(join(dir, '.draftwise'), { recursive: true });
+    await expect(
+      tasksCommand([], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/Run `draftwise init` first/);
+  });
+
+  it('errors when there are no technical specs yet', async () => {
+    await seedSpec(dir, 'alpha', { technical: null });
+    await expect(
+      tasksCommand([], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/No technical specs found/);
+  });
+
+  it('auto-picks the only spec with a technical-spec.md', async () => {
+    await seedSpec(dir, 'collab-albums', { technical: '# Tech\n\nReal.' });
+
+    let captured;
+    await tasksCommand([], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+      }),
+      complete: async (req) => {
+        captured = req;
+        return '# Tasks\n\n1. Schema change';
+      },
+    });
+
+    expect(logs.join('\n')).toContain('Using the only technical spec: collab-albums');
+    expect(captured.system).toContain('tasks.md');
+    expect(captured.prompt).toContain('# Tech');
+
+    const tasks = await readFile(
+      join(dir, '.draftwise', 'specs', 'collab-albums', 'tasks.md'),
+      'utf8',
+    );
+    expect(tasks).toContain('# Tasks');
+  });
+
+  it('uses the slug arg when given', async () => {
+    await seedSpec(dir, 'alpha');
+    await seedSpec(dir, 'beta');
+
+    await tasksCommand(['beta'], {
+      cwd: dir,
+      log: () => {},
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+      }),
+      complete: async () => '# Beta tasks',
+    });
+
+    const tasks = await readFile(
+      join(dir, '.draftwise', 'specs', 'beta', 'tasks.md'),
+      'utf8',
+    );
+    expect(tasks).toBe('# Beta tasks');
+  });
+
+  it('errors when an unknown slug is requested', async () => {
+    await seedSpec(dir, 'alpha');
+    await expect(
+      tasksCommand(['ghost'], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/No technical spec found for "ghost"/);
+  });
+
+  it('skips specs missing a technical-spec.md', async () => {
+    await seedSpec(dir, 'alpha', { technical: null });
+    await seedSpec(dir, 'beta');
+
+    await tasksCommand([], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+      }),
+      complete: async () => '# Tasks',
+    });
+
+    expect(logs.join('\n')).toContain('Using the only technical spec: beta');
+    await expect(
+      readFile(join(dir, '.draftwise', 'specs', 'alpha', 'tasks.md')),
+    ).rejects.toThrow();
+  });
+
+  it('agent mode dumps technical spec + scanner + instruction without writing', async () => {
+    await seedSpec(dir, 'collab-albums', { technical: '# Tech\n\nReal stuff.' });
+
+    await tasksCommand([], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => SAMPLE_SCAN,
+      loadConfig: async () => ({ mode: 'agent' }),
+      complete: async () => {
+        throw new Error('should not be called in agent mode');
+      },
+    });
+
+    const output = logs.join('\n');
+    expect(output).toContain('SPEC: collab-albums');
+    expect(output).toContain('TECHNICAL SPEC');
+    expect(output).toContain('# Tech');
+    expect(output).toContain('SCANNER OUTPUT');
+    expect(output).toContain('INSTRUCTION');
+
+    await expect(
+      readFile(join(dir, '.draftwise', 'specs', 'collab-albums', 'tasks.md')),
+    ).rejects.toThrow();
+  });
+
+  it('errors when the technical spec is empty', async () => {
+    await seedSpec(dir, 'empty', { technical: '' });
+
+    await expect(
+      tasksCommand([], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({ mode: 'agent' }),
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/empty/);
+  });
+});


### PR DESCRIPTION
Reads an approved technical-spec.md and drafts tasks.md — an ordered, dependency-aware breakdown an engineer can pick up. Each task has Goal, Files (real paths or "(new)" markers), Depends on, Parallel with, and Acceptance criteria. Sections: title, Overview, Tasks, Suggested execution order, Open questions.

Selection mirrors `tech`: pass a slug, auto-pick when one technical-spec.md exists, prompt when multiple. Filters out specs without a technical-spec — message redirects to `draftwise tech` first. Existing tasks.md is overwritten (flagged in the picker).

Hard rule shared with the rest of the chain: file paths come from the scanner / technical spec, not invention. New files get "(new)".

8 new tests cover both modes, the four selection paths, the empty- input error, and the "no technical specs yet" guard.