### PR TITLE
Implement draftwise list and show <feature> [type]

### DIFF
--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -1,0 +1,72 @@
+import { readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { listSpecs as defaultListSpecs } from '../utils/specs.js';
+
+async function pathExists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readTitle(file) {
+  try {
+    const content = await readFile(file, 'utf8');
+    const m = content.match(/^\s*#\s+(.+)$/m);
+    return m ? m[1].trim() : '';
+  } catch {
+    return '';
+  }
+}
+
+function buildStatus(spec) {
+  const parts = [];
+  if (spec.hasProductSpec) parts.push('product');
+  if (spec.hasTechnicalSpec) parts.push('tech');
+  if (spec.hasTasks) parts.push('tasks');
+  return parts.join(' · ') || '(empty)';
+}
+
+function pad(s, n) {
+  return s.length >= n ? s : s + ' '.repeat(n - s.length);
+}
+
+export default async function listCommand(_args = [], deps = {}) {
+  const cwd = deps.cwd ?? process.cwd();
+  const log = deps.log ?? ((msg) => console.log(msg));
+  const listSpecs = deps.listSpecs ?? defaultListSpecs;
+
+  const draftwiseDir = join(cwd, '.draftwise');
+  if (!(await pathExists(draftwiseDir))) {
+    throw new Error('.draftwise/ not found. Run `draftwise init` first.');
+  }
+
+  const specs = await listSpecs(cwd);
+  if (specs.length === 0) {
+    log('No specs yet. Run `draftwise new "<idea>"` to draft one.');
+    return;
+  }
+
+  const rows = await Promise.all(
+    specs.map(async (s) => ({
+      slug: s.slug,
+      status: buildStatus(s),
+      title: s.hasProductSpec ? await readTitle(s.productSpec) : '',
+    })),
+  );
+
+  const slugWidth = Math.max(4, ...rows.map((r) => r.slug.length));
+  const statusWidth = Math.max(6, ...rows.map((r) => r.status.length));
+
+  log(`${rows.length} spec${rows.length === 1 ? '' : 's'} in .draftwise/specs/`);
+  log('');
+  log(`${pad('SLUG', slugWidth)}  ${pad('STATUS', statusWidth)}  TITLE`);
+  log(
+    `${'-'.repeat(slugWidth)}  ${'-'.repeat(statusWidth)}  ${'-'.repeat(20)}`,
+  );
+  for (const r of rows) {
+    log(`${pad(r.slug, slugWidth)}  ${pad(r.status, statusWidth)}  ${r.title}`);
+  }
+}

--- a/src/commands/show.js
+++ b/src/commands/show.js
@@ -1,0 +1,70 @@
+import { readFile, access } from 'node:fs/promises';
+import { join } from 'node:path';
+import { listSpecs as defaultListSpecs } from '../utils/specs.js';
+
+const VALID_TYPES = ['product', 'tech', 'tasks'];
+
+const TYPE_TO_FILE = {
+  product: 'productSpec',
+  tech: 'technicalSpec',
+  tasks: 'tasks',
+};
+
+const TYPE_TO_FILENAME = {
+  product: 'product-spec.md',
+  tech: 'technical-spec.md',
+  tasks: 'tasks.md',
+};
+
+async function pathExists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export default async function showCommand(args = [], deps = {}) {
+  const cwd = deps.cwd ?? process.cwd();
+  const log = deps.log ?? ((msg) => console.log(msg));
+  const listSpecs = deps.listSpecs ?? defaultListSpecs;
+
+  const slug = args[0];
+  const type = args[1] ?? 'product';
+
+  if (!slug) {
+    throw new Error(
+      'Usage: draftwise show <feature> [product|tech|tasks]  (default type: product)',
+    );
+  }
+  if (!VALID_TYPES.includes(type)) {
+    throw new Error(
+      `Invalid spec type "${type}". Must be one of: ${VALID_TYPES.join(', ')}.`,
+    );
+  }
+
+  const draftwiseDir = join(cwd, '.draftwise');
+  if (!(await pathExists(draftwiseDir))) {
+    throw new Error('.draftwise/ not found. Run `draftwise init` first.');
+  }
+
+  const specs = await listSpecs(cwd);
+  const target = specs.find((s) => s.slug === slug);
+  if (!target) {
+    const available = specs.map((s) => s.slug).join(', ') || '(none yet)';
+    throw new Error(
+      `No spec found for "${slug}". Available: ${available}`,
+    );
+  }
+
+  const filePath = target[TYPE_TO_FILE[type]];
+  if (!(await pathExists(filePath))) {
+    throw new Error(
+      `${TYPE_TO_FILENAME[type]} not found for "${slug}". Run \`draftwise ${type === 'product' ? 'new' : type}\` to generate it.`,
+    );
+  }
+
+  const content = await readFile(filePath, 'utf8');
+  log(content);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,8 @@ const COMMANDS = {
   new: () => import('./commands/new.js'),
   tech: () => import('./commands/tech.js'),
   tasks: () => import('./commands/tasks.js'),
+  list: () => import('./commands/list.js'),
+  show: () => import('./commands/show.js'),
 };
 
 const HELP = `draftwise — codebase-aware spec drafting
@@ -13,12 +15,14 @@ Usage:
   draftwise <command> [args]
 
 Commands:
-  init                  Scan codebase and set up .draftwise/
-  scan                  Refresh the codebase overview
-  explain <flow>        Trace how a specific flow works in the code
-  new "<idea>"          Conversational drafting → product-spec.md
-  tech [<feature>]      Draft technical-spec.md from approved product spec
-  tasks [<feature>]     Generate ordered tasks.md from technical spec
+  init                          Scan codebase and set up .draftwise/
+  scan                          Refresh the codebase overview
+  explain <flow>                Trace how a specific flow works in the code
+  new "<idea>"                  Conversational drafting → product-spec.md
+  tech [<feature>]              Draft technical-spec.md from approved product spec
+  tasks [<feature>]             Generate ordered tasks.md from technical spec
+  list                          List all specs in .draftwise/specs/
+  show <feature> [type]         Show a spec (type: product | tech | tasks; default: product)
 
 Run "draftwise <command> --help" for command-specific help (coming soon).
 `;

--- a/test/commands/list.test.js
+++ b/test/commands/list.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import listCommand from '../../src/commands/list.js';
+
+async function seedSpec(dir, slug, files) {
+  const specDir = join(dir, '.draftwise', 'specs', slug);
+  await mkdir(specDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    await writeFile(join(specDir, name), content, 'utf8');
+  }
+}
+
+describe('draftwise list', () => {
+  let dir;
+  let logs;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-list-'));
+    await mkdir(join(dir, '.draftwise'));
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('errors if .draftwise/ is missing', async () => {
+    await rm(join(dir, '.draftwise'), { recursive: true });
+    await expect(
+      listCommand([], { cwd: dir, log: () => {} }),
+    ).rejects.toThrow(/Run `draftwise init` first/);
+  });
+
+  it('shows a friendly message when there are no specs', async () => {
+    await listCommand([], { cwd: dir, log: (m) => logs.push(m) });
+    expect(logs.join('\n')).toContain('No specs yet');
+  });
+
+  it('lists each spec with its status flags and title', async () => {
+    await seedSpec(dir, 'collab-albums', {
+      'product-spec.md': '# Collaborative Albums\n\nBody.',
+      'technical-spec.md': '# Tech\n',
+      'tasks.md': '# Tasks\n',
+    });
+    await seedSpec(dir, 'mute-notifications', {
+      'product-spec.md': '# Mute notifications\n\nBody.',
+    });
+
+    await listCommand([], { cwd: dir, log: (m) => logs.push(m) });
+    const out = logs.join('\n');
+    expect(out).toContain('2 specs');
+    expect(out).toMatch(/collab-albums.*product · tech · tasks.*Collaborative Albums/);
+    expect(out).toMatch(/mute-notifications.*product\b.*Mute notifications/);
+  });
+
+  it('marks empty spec dirs as (empty)', async () => {
+    await mkdir(join(dir, '.draftwise', 'specs', 'half-baked'), { recursive: true });
+
+    await listCommand([], { cwd: dir, log: (m) => logs.push(m) });
+    expect(logs.join('\n')).toContain('(empty)');
+  });
+});

--- a/test/commands/show.test.js
+++ b/test/commands/show.test.js
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import showCommand from '../../src/commands/show.js';
+
+async function seedSpec(dir, slug, files) {
+  const specDir = join(dir, '.draftwise', 'specs', slug);
+  await mkdir(specDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    await writeFile(join(specDir, name), content, 'utf8');
+  }
+}
+
+describe('draftwise show', () => {
+  let dir;
+  let logs;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-show-'));
+    await mkdir(join(dir, '.draftwise'));
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('errors if no slug was given', async () => {
+    await expect(
+      showCommand([], { cwd: dir, log: () => {} }),
+    ).rejects.toThrow(/Usage: draftwise show/);
+  });
+
+  it('errors if .draftwise/ is missing', async () => {
+    await rm(join(dir, '.draftwise'), { recursive: true });
+    await expect(
+      showCommand(['collab-albums'], { cwd: dir, log: () => {} }),
+    ).rejects.toThrow(/Run `draftwise init` first/);
+  });
+
+  it('errors when type is invalid', async () => {
+    await seedSpec(dir, 'collab-albums', { 'product-spec.md': '# x' });
+    await expect(
+      showCommand(['collab-albums', 'bogus'], { cwd: dir, log: () => {} }),
+    ).rejects.toThrow(/Invalid spec type "bogus"/);
+  });
+
+  it('errors when slug is unknown', async () => {
+    await seedSpec(dir, 'alpha', { 'product-spec.md': '# x' });
+    await expect(
+      showCommand(['ghost'], { cwd: dir, log: () => {} }),
+    ).rejects.toThrow(/No spec found for "ghost"/);
+  });
+
+  it('errors when the requested type isnt generated yet', async () => {
+    await seedSpec(dir, 'alpha', { 'product-spec.md': '# Alpha' });
+    await expect(
+      showCommand(['alpha', 'tech'], { cwd: dir, log: () => {} }),
+    ).rejects.toThrow(/technical-spec\.md not found/);
+  });
+
+  it('shows product spec by default', async () => {
+    await seedSpec(dir, 'collab-albums', {
+      'product-spec.md': '# Product\n\nProduct body.',
+    });
+
+    await showCommand(['collab-albums'], { cwd: dir, log: (m) => logs.push(m) });
+    expect(logs.join('\n')).toContain('# Product');
+    expect(logs.join('\n')).toContain('Product body.');
+  });
+
+  it('shows tech spec when type=tech', async () => {
+    await seedSpec(dir, 'collab-albums', {
+      'product-spec.md': '# Product',
+      'technical-spec.md': '# Tech\n\nTech body.',
+    });
+
+    await showCommand(['collab-albums', 'tech'], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+    });
+    const out = logs.join('\n');
+    expect(out).toContain('# Tech');
+    expect(out).not.toContain('Product');
+  });
+
+  it('shows tasks when type=tasks', async () => {
+    await seedSpec(dir, 'collab-albums', {
+      'product-spec.md': '# Product',
+      'technical-spec.md': '# Tech',
+      'tasks.md': '# Tasks\n\n1. First task',
+    });
+
+    await showCommand(['collab-albums', 'tasks'], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+    });
+    expect(logs.join('\n')).toContain('1. First task');
+  });
+});


### PR DESCRIPTION
Two file-system utilities, no AI involved.

list enumerates .draftwise/specs/, prints a three-column table (slug, status flags, title pulled from product-spec.md's first H1). Status flags are "product · tech · tasks" or "(empty)" so the user can see at a glance which specs are complete.

show <feature> [type] prints the requested spec to terminal. type defaults to "product"; valid alternatives are "tech" and "tasks". Friendly errors for unknown slug, invalid type, missing .draftwise/, or asking for a type that hasn't been generated yet (the message points at the right command to run next).

12 new tests across both commands. Closes the v1 build order: init, scan, explain, new, tech, tasks, list, show — all shipped.