### PR TITLE
Make new / tech / tasks greenfield-aware; degrade scan / explain grac…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,8 @@ src/commands/             → one file per CLI command, default export async fn
 src/core/scanner.js       → codebase scanning (frameworks, routes, components, models)
 src/ai/provider.js        → routes complete() calls to the right provider adapter
 src/ai/providers/         → claude.js wired; openai.js + gemini.js stubbed
-src/ai/prompts/           → one prompt module per command (system + buildPrompt + agent instruction)
-src/utils/                → config.js (yaml loader), specs.js (list .draftwise/specs/), slug.js
+src/ai/prompts/           → one prompt module per command. Each exports brownfield + greenfield SYSTEM constants, a selectSystem(projectState) helper, a buildPrompt() that branches on projectState, and an agent-mode instruction
+src/utils/                → config.js (yaml loader, returns projectState + stack), specs.js (list .draftwise/specs/), slug.js, overview.js (read .draftwise/overview.md for greenfield context)
 test/                     → vitest, mirrors src structure
 ```
 
@@ -81,8 +81,14 @@ Configured in `.draftwise/config.yaml`:
 ai:
   mode: agent | api
   provider: claude | openai | gemini  # only if mode: api
+  api_key_env: ANTHROPIC_API_KEY      # only if mode: api
   model: ""                            # optional override
+project:
+  state: greenfield | brownfield      # set by `draftwise init`; controls prompt routing
+  stack: "Next.js + Postgres + Prisma" # greenfield only; the stack the PM picked at init
 ```
+
+`loadConfig()` in `src/utils/config.js` defaults `project.state` to `brownfield` for back-compat with configs written before the greenfield routing landed.
 
 ---
 
@@ -143,15 +149,15 @@ The build order below was the original sequence. As of `0.0.1` published to npm,
    - **Greenfield path:** prompts for the idea, then in **api mode** generates clarifying questions → captures answers → proposes 2-3 stack options with rationale/pros/cons/directory structure/setup commands → writes a full greenfield plan to `overview.md` + `config.yaml` (with `project.state: greenfield` and the chosen `stack`). In **agent mode**, prints a 3-phase instruction for the host coding agent to walk the conversation and rewrite `overview.md`.
    Refuses if `.draftwise/` already exists. (`src/commands/init.js`, prompts in `src/ai/prompts/greenfield.js`)
 
-2. **`scan`** ✅ — runs the scanner and (api mode) calls the model to produce a narrated `overview.md`, or (agent mode) dumps scanner data + an instruction for the host agent. (`src/commands/scan.js`)
+2. **`scan`** ✅ — brownfield: runs the scanner and (api) calls the model to produce a narrated `overview.md`, or (agent) dumps scanner data + an instruction for the host agent. Greenfield: short-circuits with a friendly "no code yet" message — `overview.md` is the greenfield plan from `init`. (`src/commands/scan.js`)
 
-3. **`explain <flow>`** ✅ — traces a single flow end-to-end. Saves a snapshot to `.draftwise/flows/<slug>.md` in api mode. (`src/commands/explain.js`)
+3. **`explain <flow>`** ✅ — brownfield: traces a single flow end-to-end. Greenfield: short-circuits with a friendly message (no flows to trace yet). (`src/commands/explain.js`)
 
-4. **`new "<idea>"`** ✅ — three-phase conversational drafting: AI plan call (returns JSON with affected_flows, clarifying_questions, adjacent_opportunities) → inquirer Q&A + accept/decline loop → AI synthesis call → `product-spec.md`. Hard rule: never assume — turn every gap into a question. (`src/commands/new.js`)
+4. **`new "<idea>"`** ✅ — brownfield: three-phase conversational drafting (AI plan call returns JSON with affected_flows / clarifying_questions / adjacent_opportunities → inquirer Q&A + accept/decline loop → AI synthesis call → `product-spec.md`). Greenfield: skips the scanner and reads `overview.md` (the project plan from `init`); plan call returns clarifying questions only (no affected_flows / adjacent_opportunities — there's nothing existing to integrate with); synthesis writes a spec without "Affected flows" / "Adjacent changes" sections. Hard rule shared across both modes: never assume — turn every gap into a question. (`src/commands/new.js`, prompts in `src/ai/prompts/new.js` with `selectPlanSystem` / `selectSpecSystem`)
 
-5. **`tech [<feature>]`** ✅ — reads product-spec.md, drafts technical-spec.md grounded in scanner output. Auto-picks if one feature, prompts to choose if multiple. (`src/commands/tech.js`)
+5. **`tech [<feature>]`** ✅ — brownfield: reads `product-spec.md`, drafts `technical-spec.md` grounded in scanner output. Greenfield: skips scanner, reads `overview.md` (the project plan), drafts `technical-spec.md` with every file path marked `(new)` and the chosen stack's conventions. (`src/commands/tech.js`, `src/ai/prompts/tech.js` with `selectSystem`)
 
-6. **`tasks [<feature>]`** ✅ — reads technical-spec.md, drafts ordered tasks.md (each with Goal, Files, Depends on, Parallel with, Acceptance). (`src/commands/tasks.js`)
+6. **`tasks [<feature>]`** ✅ — brownfield: reads `technical-spec.md`, drafts ordered `tasks.md` (Goal / Files / Depends on / Parallel with / Acceptance). Greenfield: reads the project plan + technical spec, drafts `tasks.md` where files are all `(new)` and the first 1-3 tasks are foundational scaffolding (run setup commands, install deps, configure env). (`src/commands/tasks.js`, `src/ai/prompts/tasks.js` with `selectSystem`)
 
 7. **`list` and `show <feature> [type]`** ✅ — file-system utilities, no AI. (`src/commands/list.js`, `src/commands/show.js`)
 

--- a/README.md
+++ b/README.md
@@ -247,13 +247,12 @@ Until the OpenAI and Gemini adapters land, pick `agent` mode at `draftwise init`
 v1 commands are all shipped on `npm` as of `0.0.1`. The next published release will be `0.1.0` after end-to-end smoke testing on a sample repo.
 
 - [x] `init` — `.draftwise/` setup, with greenfield (stack recommendation) and brownfield (codebase scan) routing
-- [x] `scan` — structured product overview (brownfield)
-- [x] `explain` — traced walkthroughs of specific flows (brownfield)
-- [x] `new` — conversational spec drafting
-- [x] `tech` — technical spec grounded in real code
-- [x] `tasks` — dependency-ordered implementation breakdown
+- [x] `scan` — structured product overview (brownfield); friendly short-circuit in greenfield
+- [x] `explain` — traced walkthroughs of specific flows (brownfield); friendly short-circuit in greenfield
+- [x] `new` — conversational spec drafting, greenfield-aware (drops affected_flows / adjacent_opportunities when there's no code yet)
+- [x] `tech` — technical spec, greenfield-aware (every file marked `(new)`, follows the planned directory structure)
+- [x] `tasks` — dependency-ordered breakdown, greenfield-aware (first 1-3 tasks are project setup before feature work)
 - [x] `list` and `show` — spec browsing utilities
-- [ ] greenfield-aware `new` / `tech` / `tasks` — drop scanner-grounded constraints when there's no code yet (planned)
 - [ ] optional file scaffolding from `init`'s greenfield plan (planned)
 
 **Next:** OpenAI and Gemini provider adapters (Claude is the only fully-wired adapter today), framework support beyond JS/TS Node (Python, Go, Rust), greenfield-aware downstream commands, and a flag-aware scanner cache for very large repos.

--- a/src/ai/prompts/new.js
+++ b/src/ai/prompts/new.js
@@ -1,4 +1,4 @@
-export const PLAN_SYSTEM = `You are Draftwise, a codebase-aware product spec drafting tool.
+export const PLAN_SYSTEM_BROWNFIELD = `You are Draftwise, a codebase-aware product spec drafting tool.
 
 A PM has proposed a new feature for a real codebase. Your job in this turn is NOT to write the spec yet. Your job is to plan the conversation that will lead to a good spec.
 
@@ -33,7 +33,47 @@ Hard rules:
 - Output JSON only. No markdown around it except the single fenced block.
 `;
 
-export function buildPlanPrompt({ idea, scan, packageMeta }) {
+export const PLAN_SYSTEM_GREENFIELD = `You are Draftwise, a product spec drafting tool. The PM is scoping a feature for a GREENFIELD project — there's no existing code yet. They've already chosen a stack and a directory plan, captured in overview.md.
+
+Your job in this turn is NOT to write the spec yet. Your job is to plan the conversation by generating clarifying questions tailored to this feature on top of the chosen plan.
+
+Return ONE JSON object inside a single fenced \`\`\`json block:
+
+{
+  "feature_slug": "kebab-case (3-5 words)",
+  "feature_title": "human-readable title",
+  "clarifying_questions": [
+    { "text": "the question",
+      "why": "what gap this fills — be specific to the project plan" }
+  ]
+}
+
+Hard rules:
+- ASK, DO NOT ASSUME. 4-8 clarifying questions specific to this feature on top of the chosen stack: user behavior, edge cases, integration points within the planned structure, scope boundaries, success criteria.
+- Don't ask stack-selection questions — that decision is already made (see overview.md).
+- Don't generate affected_flows or adjacent_opportunities — there are no existing flows yet. If integration with the planned structure matters, surface it as a clarifying question.
+- Output JSON only. No markdown around the fenced block.
+`;
+
+export function selectPlanSystem(projectState) {
+  return projectState === 'greenfield'
+    ? PLAN_SYSTEM_GREENFIELD
+    : PLAN_SYSTEM_BROWNFIELD;
+}
+
+export function buildPlanPrompt({ idea, scan, packageMeta, projectState, overview }) {
+  if (projectState === 'greenfield') {
+    return [
+      `PM's idea: "${idea}"`,
+      '',
+      'Project plan (overview.md — chosen stack, directory structure, setup):',
+      overview && overview.trim()
+        ? overview
+        : '_(no overview.md found; treat the idea as the only context)_',
+      '',
+      'Generate clarifying questions per the system instructions.',
+    ].join('\n');
+  }
   return [
     `PM's idea: "${idea}"`,
     '',
@@ -51,9 +91,17 @@ export function buildPlanPrompt({ idea, scan, packageMeta }) {
   ].join('\n');
 }
 
+function extractJsonFromFence(text) {
+  const opener = text.match(/```(?:json)?\s*\n?/);
+  if (!opener) return text.trim();
+  const start = opener.index + opener[0].length;
+  const lastFence = text.lastIndexOf('```');
+  if (lastFence <= start) return text.slice(start).trim();
+  return text.slice(start, lastFence).trim();
+}
+
 export function parsePlanResponse(text) {
-  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/);
-  const raw = (fenced ? fenced[1] : text).trim();
+  const raw = extractJsonFromFence(text);
   let parsed;
   try {
     parsed = JSON.parse(raw);
@@ -76,7 +124,7 @@ export function parsePlanResponse(text) {
   };
 }
 
-export const SPEC_SYSTEM = `You are Draftwise, a codebase-aware product spec drafting tool.
+export const SPEC_SYSTEM_BROWNFIELD = `You are Draftwise, a codebase-aware product spec drafting tool.
 
 You have the PM's idea, the codebase scanner output, the PM's answers to clarifying questions, and the PM's accept/decline decisions on adjacent flow opportunities. Your job in this turn is to write the final product-spec.md.
 
@@ -129,11 +177,93 @@ Hard rules:
 - Output the markdown only. No preamble. Start with the title.
 `;
 
-export function buildSpecPrompt({ idea, plan, scan, packageMeta, answers, opportunityDecisions }) {
+export const SPEC_SYSTEM_GREENFIELD = `You are Draftwise. The PM is scoping a feature for a GREENFIELD project. You have the idea, the project plan (overview.md — chosen stack, directory structure), and answers to clarifying questions. Write product-spec.md.
+
+The spec has these sections, in order:
+
+# <Feature title>
+
+> One-sentence description.
+
+## Problem
+Concrete; cite what the PM said in answers. No generic prose.
+
+## Users
+Who this is for, drawn from answers.
+
+## User stories
+3-7 stories in "As a <user>, I want <action>, so that <outcome>" form.
+
+## Acceptance criteria
+Given/when/then bullets. Concrete, testable.
+
+## Edge cases
+What could go wrong, what should happen. Anchor in the answers; don't invent.
+
+## Test cases
+Product-level scenarios. Happy path + each edge case.
+
+## Scope
+Four sub-bullets:
+- **Covered:** what this spec includes
+- **Assumed:** what we're taking as given
+- **Hypothesized:** what we believe but haven't proven
+- **Out of scope:** what this spec explicitly excludes
+
+## Core metrics
+What success looks like. Measurable.
+
+## Counter metrics
+What could go wrong if we succeed too hard.
+
+Hard rules:
+- Greenfield project — there are no existing flows or files. Don't include "Affected flows" or "Adjacent changes" sections; they don't apply.
+- If something feels like an integration with the planned structure, mention the planned file/component (from overview.md) but mark it forward-looking.
+- If a section has no content, write "_None._" — don't fabricate.
+- Output the markdown only. No preamble. Start with the title.
+`;
+
+export function selectSpecSystem(projectState) {
+  return projectState === 'greenfield'
+    ? SPEC_SYSTEM_GREENFIELD
+    : SPEC_SYSTEM_BROWNFIELD;
+}
+
+export function buildSpecPrompt({
+  idea,
+  plan,
+  scan,
+  packageMeta,
+  answers,
+  opportunityDecisions,
+  projectState,
+  overview,
+}) {
   const qa = plan.clarifyingQuestions.map((q, i) => ({
     question: q.text,
     answer: answers[i] ?? '',
   }));
+
+  if (projectState === 'greenfield') {
+    return [
+      `PM's idea: "${idea}"`,
+      `Feature slug: ${plan.featureSlug}`,
+      `Feature title: ${plan.featureTitle}`,
+      '',
+      'Project plan (overview.md):',
+      overview && overview.trim()
+        ? overview
+        : '_(no overview.md found)_',
+      '',
+      "PM's answers to clarifying questions:",
+      '```json',
+      JSON.stringify(qa, null, 2),
+      '```',
+      '',
+      'Write the full product-spec.md per the system instructions.',
+    ].join('\n');
+  }
+
   const opportunities = plan.adjacentOpportunities.map((o, i) => ({
     flow: o.flow,
     suggestion: o.suggestion,
@@ -175,7 +305,27 @@ export function buildSpecPrompt({ idea, plan, scan, packageMeta, answers, opport
   ].join('\n');
 }
 
-export function buildAgentInstruction(idea) {
+export function buildAgentInstruction(idea, projectState = 'brownfield') {
+  if (projectState === 'greenfield') {
+    return `The PM has proposed a feature for a GREENFIELD project: "${idea}".
+
+The project plan (overview.md above) describes the chosen stack and directory structure. There is no existing code yet. Run a conversation with the PM in three phases:
+
+PHASE 1 — Plan the conversation:
+  - Draft 4-8 clarifying questions specific to this feature on top of the chosen plan: user behavior, edge cases, integration points within the planned structure, scope, success criteria.
+  - Don't ask stack-selection questions — that decision is in overview.md.
+  - Don't try to enumerate "affected flows" — there are no existing flows yet.
+
+PHASE 2 — Walk the PM through the questions:
+  - Ask one clarifying question at a time. Wait for the answer.
+
+PHASE 3 — Generate product-spec.md:
+  - Sections in order: Problem, Users, User stories, Acceptance criteria, Edge cases, Test cases, Scope (covered/assumed/hypothesized/out of scope), Core metrics, Counter metrics.
+  - Skip "Affected flows" and "Adjacent changes" — they don't apply for greenfield.
+  - Save to .draftwise/specs/<feature-slug>/product-spec.md.
+
+Hard rule: ASK don't assume; ground every claim in the answers and the project plan, never invented detail.`;
+  }
   return `The PM has proposed: "${idea}".
 
 Use the scanner data above as ground truth for the existing codebase. Run a conversation with the PM in three phases:
@@ -197,3 +347,7 @@ PHASE 3 — Generate product-spec.md:
 
 Hard rules: ground every claim in the scanner; turn every gap into a question, not an assumption; keep the spec tight.`;
 }
+
+// Backwards compatibility — keep the old names alive as aliases.
+export const PLAN_SYSTEM = PLAN_SYSTEM_BROWNFIELD;
+export const SPEC_SYSTEM = SPEC_SYSTEM_BROWNFIELD;

--- a/src/ai/prompts/tasks.js
+++ b/src/ai/prompts/tasks.js
@@ -1,4 +1,4 @@
-export const SYSTEM = `You are Draftwise, a codebase-aware tool that breaks technical specs into ordered implementation tasks.
+export const SYSTEM_BROWNFIELD = `You are Draftwise, a codebase-aware tool that breaks technical specs into ordered implementation tasks.
 
 You will receive: an approved technical-spec.md (already grounded in the real codebase) and the structured scanner output. Your job is to write tasks.md — an ordered breakdown an engineer can pick up and ship from.
 
@@ -38,7 +38,73 @@ Hard rules:
 - Output the markdown only. No preamble. Start with the title.
 `;
 
-export function buildPrompt({ technicalSpec, scan, packageMeta }) {
+export const SYSTEM_GREENFIELD = `You are Draftwise. The PM has approved a technical spec for a feature in a GREENFIELD project. The chosen stack and directory plan are in overview.md. Write tasks.md — the ordered breakdown an engineer can pick up and ship from.
+
+Sections, in order:
+
+# <Feature title> — Tasks
+
+> One-sentence framing.
+
+## Overview
+2-3 sentences: total task count, broad shape, notable parallel tracks. Note that this is a greenfield build — first tasks are project setup before feature work.
+
+## Tasks
+Numbered list. Each task:
+
+\`\`\`
+### N. <task title>
+- **Goal:** one sentence
+- **Files:** comma-separated paths, all marked "(new)" — match the directory structure from overview.md
+- **Depends on:** task numbers or "none"
+- **Parallel with:** task numbers or "none"
+- **Acceptance:** what "done" looks like
+\`\`\`
+
+Include foundational scaffolding tasks first: running the setup commands from overview.md, configuring environment variables, writing the first config files / env file. Don't assume the project is already initialized.
+
+## Suggested execution order
+Dependency chain — what to start with, where work fans out into parallel tracks, where it merges.
+
+## Open questions
+What the engineer must resolve before/during execution. If genuinely none, write "_None._".
+
+Hard rules:
+- Greenfield. Every file path is "(new)" and must follow the directory structure from overview.md.
+- The first 1-3 tasks should be project setup (scaffold the framework, install deps, configure env). Don't skip this.
+- Each "Depends on" must point at a task number that actually exists in this doc.
+- Output markdown only. No preamble.
+`;
+
+// Backwards-compatible default
+export const SYSTEM = SYSTEM_BROWNFIELD;
+
+export function selectSystem(projectState) {
+  return projectState === 'greenfield' ? SYSTEM_GREENFIELD : SYSTEM_BROWNFIELD;
+}
+
+export function buildPrompt({
+  technicalSpec,
+  scan,
+  packageMeta,
+  projectState,
+  overview,
+}) {
+  if (projectState === 'greenfield') {
+    return [
+      'Approved technical spec (defines the work):',
+      '',
+      technicalSpec,
+      '',
+      '---',
+      '',
+      'Project plan (overview.md — chosen stack, directory structure, setup commands):',
+      '',
+      overview && overview.trim() ? overview : '_(no overview.md found)_',
+      '',
+      'Write tasks.md per the system instructions, marking every file path "(new)" and including project setup as the first 1-3 tasks.',
+    ].join('\n');
+  }
   return [
     'Approved technical spec (read carefully — it defines the work):',
     '',
@@ -60,7 +126,24 @@ export function buildPrompt({ technicalSpec, scan, packageMeta }) {
   ].join('\n');
 }
 
-export function buildAgentInstruction(slug) {
+export function buildAgentInstruction(slug, projectState = 'brownfield') {
+  if (projectState === 'greenfield') {
+    return `The technical spec above is approved. The project is GREENFIELD — there's no existing code yet. The chosen stack and directory plan are in overview.md (above).
+
+Generate tasks.md and save it to .draftwise/specs/${slug}/tasks.md.
+
+Sections in order:
+- Title + one-sentence framing
+- Overview (note that the first tasks are project setup since this is greenfield)
+- Tasks (numbered; each with Goal, Files, Depends on, Parallel with, Acceptance)
+- Suggested execution order
+- Open questions
+
+Hard rules:
+- Every file path is "(new)" and must match the directory structure from overview.md.
+- The first 1-3 tasks must be foundational scaffolding (run setup commands, install deps, configure env). Don't skip them.
+- Each "Depends on" link must point at a task number you've actually defined.`;
+  }
   return `The technical spec above is approved. Use the scanner data as ground truth. Generate tasks.md following the section structure below, ordered so each task's dependencies appear before it. Save it to .draftwise/specs/${slug}/tasks.md.
 
 Sections in order:

--- a/src/ai/prompts/tech.js
+++ b/src/ai/prompts/tech.js
@@ -1,4 +1,4 @@
-export const SYSTEM = `You are Draftwise, a codebase-aware tool that drafts technical specs from approved product specs.
+export const SYSTEM_BROWNFIELD = `You are Draftwise, a codebase-aware tool that drafts technical specs from approved product specs.
 
 You will receive: an approved product-spec.md (already through the conversational drafting phase, so it's grounded in reality), and the structured scanner output for the existing codebase. Your job is to write the technical-spec.md — the engineering counterpart that translates intent into concrete code changes.
 
@@ -36,7 +36,70 @@ Hard rules:
 - Output the markdown only. No preamble. Start with the title.
 `;
 
-export function buildPrompt({ productSpec, scan, packageMeta }) {
+export const SYSTEM_GREENFIELD = `You are Draftwise. The PM has approved a product spec for a feature in a GREENFIELD project — there's no existing code yet. The chosen stack and directory plan are in overview.md. Your job is to write technical-spec.md against the planned structure.
+
+Sections, in order:
+
+# <Feature title> — Technical spec
+
+> One-sentence framing linking to product-spec.md.
+
+## Summary
+2-4 sentences: what's being built and where it lands inside the planned architecture.
+
+## Data model changes
+For each model: name, planned file (e.g. \`prisma/schema.prisma\` (new) — match the chosen ORM from overview.md), fields, relationships, and any migration / seeding approach.
+
+## API changes
+For each endpoint: method + path, planned file (e.g. \`app/api/<route>/route.ts\` (new) — match the chosen framework's conventions), what it does.
+
+## Component changes
+For each new UI piece: name, planned file (e.g. \`app/<page>/page.tsx\` (new) or \`src/components/<Name>.tsx\` (new)), purpose.
+
+## Migration notes
+Setup ordering, environment variables, third-party services to wire up. If trivial, write "_None — ship it._".
+
+## Test plan
+Unit, integration, and end-to-end coverage tied to acceptance criteria.
+
+## Open technical questions
+Things the engineer must resolve before/during execution that the product spec doesn't pin down. Often: hosting choice, auth provider, observability, etc. If genuinely none, write "_None._".
+
+Hard rules:
+- Greenfield project. Mark every file path with "(new)" — these are files that will exist once the feature is built. Reference the planned directory structure from overview.md so the layout is consistent.
+- Match the chosen stack's conventions exactly. If overview.md says Prisma, write Prisma schema syntax. If it says Next App Router, propose \`route.ts\` / \`page.tsx\`. Don't impose foreign patterns.
+- Keep it tight. Output markdown only, no preamble.
+`;
+
+// Backwards-compatible default
+export const SYSTEM = SYSTEM_BROWNFIELD;
+
+export function selectSystem(projectState) {
+  return projectState === 'greenfield' ? SYSTEM_GREENFIELD : SYSTEM_BROWNFIELD;
+}
+
+export function buildPrompt({
+  productSpec,
+  scan,
+  packageMeta,
+  projectState,
+  overview,
+}) {
+  if (projectState === 'greenfield') {
+    return [
+      'Approved product spec (the source of intent):',
+      '',
+      productSpec,
+      '',
+      '---',
+      '',
+      'Project plan (overview.md — chosen stack, directory structure, setup commands):',
+      '',
+      overview && overview.trim() ? overview : '_(no overview.md found)_',
+      '',
+      'Write technical-spec.md per the system instructions, marking every file path "(new)".',
+    ].join('\n');
+  }
   return [
     'Approved product spec (read this carefully — it is the source of intent):',
     '',
@@ -58,7 +121,24 @@ export function buildPrompt({ productSpec, scan, packageMeta }) {
   ].join('\n');
 }
 
-export function buildAgentInstruction(slug) {
+export function buildAgentInstruction(slug, projectState = 'brownfield') {
+  if (projectState === 'greenfield') {
+    return `The product spec above is approved. The project is GREENFIELD — there's no existing code yet. The chosen stack and directory plan are in overview.md (above).
+
+Generate technical-spec.md and save it to .draftwise/specs/${slug}/technical-spec.md.
+
+Sections in order:
+- Title + one-sentence framing
+- Summary
+- Data model changes (planned files, marked "(new)", in the chosen ORM's syntax)
+- API changes (planned files, marked "(new)", in the chosen framework's conventions)
+- Component changes (planned files, marked "(new)")
+- Migration notes (setup ordering, env vars, services to wire up)
+- Test plan (tied to acceptance criteria)
+- Open technical questions
+
+Hard rule: every file path must be marked "(new)" and must follow the directory structure from overview.md. Match the chosen stack's conventions exactly — don't impose foreign patterns.`;
+  }
   return `The product spec above is approved. Use the scanner data as ground truth for the existing codebase. Generate the technical-spec.md following the section structure below, grounded in real files/routes/models from the scanner. Save it to .draftwise/specs/${slug}/technical-spec.md.
 
 Sections in order:

--- a/src/commands/explain.js
+++ b/src/commands/explain.js
@@ -47,6 +47,15 @@ export default async function explainCommand(args = [], deps = {}) {
   }
 
   const config = await loadConfig(cwd);
+
+  if (config.projectState === 'greenfield') {
+    log(`No code yet — \`draftwise explain\` traces flows that exist in the codebase.`);
+    log(
+      'Once you have implemented this flow, come back and run `draftwise explain <flow>`.',
+    );
+    return;
+  }
+
   const slug = slugify(flow);
 
   log(`Tracing "${flow}"...`);

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -4,9 +4,10 @@ import { input, select } from '@inquirer/prompts';
 import { scan as defaultScan } from '../core/scanner.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
+import { readOverview as defaultReadOverview } from '../utils/overview.js';
 import {
-  PLAN_SYSTEM,
-  SPEC_SYSTEM,
+  selectPlanSystem,
+  selectSpecSystem,
   buildPlanPrompt,
   parsePlanResponse,
   buildSpecPrompt,
@@ -23,9 +24,9 @@ const DEFAULT_PROMPTS = {
     select({
       message: `Opportunity ${index + 1}/${total} — adjacent change in "${flow}"\n  Suggestion: ${suggestion}\n  Why: ${rationale}\n  Decision:`,
       choices: [
-        { name: 'Accept — include in this spec',     value: 'accepted' },
-        { name: 'Decline — keep it out',             value: 'declined' },
-        { name: 'Defer — note it but don\'t commit', value: 'deferred' },
+        { name: 'Accept — include in this spec', value: 'accepted' },
+        { name: 'Decline — keep it out', value: 'declined' },
+        { name: "Defer — note it but don't commit", value: 'deferred' },
       ],
       default: 'declined',
     }),
@@ -58,13 +59,12 @@ export default async function newCommand(args = [], deps = {}) {
   const scan = deps.scan ?? defaultScan;
   const loadConfig = deps.loadConfig ?? defaultLoadConfig;
   const complete = deps.complete ?? defaultComplete;
+  const readOverview = deps.readOverview ?? defaultReadOverview;
   const prompts = { ...DEFAULT_PROMPTS, ...(deps.prompts ?? {}) };
 
   const idea = args.join(' ').trim();
   if (!idea) {
-    throw new Error(
-      'Missing idea. Usage: draftwise new "<your feature idea>"',
-    );
+    throw new Error('Missing idea. Usage: draftwise new "<your feature idea>"');
   }
 
   const draftwiseDir = join(cwd, '.draftwise');
@@ -73,36 +73,68 @@ export default async function newCommand(args = [], deps = {}) {
   }
 
   const config = await loadConfig(cwd);
+  const isGreenfield = config.projectState === 'greenfield';
 
   log(`Idea: "${idea}"`);
-  log('Scanning repo...');
-  const result = await scan(cwd);
-  if (!result.files || result.files.length === 0) {
-    throw new Error(
-      `No source files found under ${cwd}. Run \`draftwise new\` from your repo root.`,
-    );
+
+  let scanForPrompt;
+  let packageMeta;
+  let overview;
+
+  if (isGreenfield) {
+    log('Reading project plan from overview.md...');
+    overview = await readOverview(cwd);
+    if (!overview.trim()) {
+      throw new Error(
+        'Greenfield project but .draftwise/overview.md is missing or empty. Re-run `draftwise init` to generate the plan, or switch the config to brownfield once code exists.',
+      );
+    }
+    scanForPrompt = null;
+    packageMeta = null;
+  } else {
+    log('Scanning repo...');
+    const result = await scan(cwd);
+    if (!result.files || result.files.length === 0) {
+      throw new Error(
+        `No source files found under ${cwd}. Run \`draftwise new\` from your repo root.`,
+      );
+    }
+    scanForPrompt = compactScan(result);
+    packageMeta = result.packageMeta;
   }
-  const scanForPrompt = compactScan(result);
 
   if (config.mode === 'agent') {
     log('');
-    log('Agent mode — handing scanner data + the conversation plan off to your coding agent.');
+    if (isGreenfield) {
+      log(
+        'Agent mode — handing the project plan + conversation off to your coding agent.',
+      );
+    } else {
+      log(
+        'Agent mode — handing scanner data + the conversation plan off to your coding agent.',
+      );
+    }
     log('');
     log('---');
     log(`IDEA: ${idea}`);
     log('');
-    log('SCANNER OUTPUT');
-    log('```json');
-    log(JSON.stringify(scanForPrompt, null, 2));
-    log('```');
-    log('');
-    log('PACKAGE METADATA');
-    log('```json');
-    log(JSON.stringify(result.packageMeta, null, 2));
-    log('```');
+    if (isGreenfield) {
+      log('PROJECT PLAN (overview.md)');
+      log(overview);
+    } else {
+      log('SCANNER OUTPUT');
+      log('```json');
+      log(JSON.stringify(scanForPrompt, null, 2));
+      log('```');
+      log('');
+      log('PACKAGE METADATA');
+      log('```json');
+      log(JSON.stringify(packageMeta, null, 2));
+      log('```');
+    }
     log('');
     log('INSTRUCTION');
-    log(buildAgentInstruction(idea));
+    log(buildAgentInstruction(idea, config.projectState));
     return;
   }
 
@@ -111,11 +143,13 @@ export default async function newCommand(args = [], deps = {}) {
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
     model: config.model,
-    system: PLAN_SYSTEM,
+    system: selectPlanSystem(config.projectState),
     prompt: buildPlanPrompt({
       idea,
       scan: scanForPrompt,
-      packageMeta: result.packageMeta,
+      packageMeta,
+      projectState: config.projectState,
+      overview,
     }),
   });
 
@@ -149,7 +183,9 @@ export default async function newCommand(args = [], deps = {}) {
   const opportunityDecisions = [];
   if (plan.adjacentOpportunities.length > 0) {
     log('');
-    log(`Pitching ${plan.adjacentOpportunities.length} adjacent opportunities:`);
+    log(
+      `Pitching ${plan.adjacentOpportunities.length} adjacent opportunities:`,
+    );
     log('');
     for (let i = 0; i < plan.adjacentOpportunities.length; i++) {
       const o = plan.adjacentOpportunities[i];
@@ -170,14 +206,16 @@ export default async function newCommand(args = [], deps = {}) {
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
     model: config.model,
-    system: SPEC_SYSTEM,
+    system: selectSpecSystem(config.projectState),
     prompt: buildSpecPrompt({
       idea,
       plan,
       scan: scanForPrompt,
-      packageMeta: result.packageMeta,
+      packageMeta,
       answers,
       opportunityDecisions,
+      projectState: config.projectState,
+      overview,
     }),
   });
 
@@ -188,5 +226,7 @@ export default async function newCommand(args = [], deps = {}) {
 
   log('');
   log(`Wrote .draftwise/specs/${slug}/product-spec.md`);
-  log('Next: review, refine, then run `draftwise tech` to generate the technical spec.');
+  log(
+    'Next: review, refine, then run `draftwise tech` to generate the technical spec.',
+  );
 }

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -41,6 +41,17 @@ export default async function scanCommand(_args = [], deps = {}) {
 
   const config = await loadConfig(cwd);
 
+  if (config.projectState === 'greenfield') {
+    log('No code yet — `draftwise scan` works on existing codebases.');
+    log(
+      'Once you have some code on disk, run scan to refresh .draftwise/overview.md from the actual code.',
+    );
+    log('');
+    log('In the meantime, the greenfield plan is in .draftwise/overview.md and');
+    log('`draftwise new "<feature idea>"` is the next step toward a spec.');
+    return;
+  }
+
   log('Scanning repo...');
   const result = await scan(cwd);
 

--- a/src/commands/tasks.js
+++ b/src/commands/tasks.js
@@ -5,14 +5,21 @@ import { scan as defaultScan } from '../core/scanner.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { listSpecs as defaultListSpecs } from '../utils/specs.js';
-import { SYSTEM, buildPrompt, buildAgentInstruction } from '../ai/prompts/tasks.js';
+import { readOverview as defaultReadOverview } from '../utils/overview.js';
+import {
+  selectSystem,
+  buildPrompt,
+  buildAgentInstruction,
+} from '../ai/prompts/tasks.js';
 
 const DEFAULT_PROMPTS = {
   pickSpec: ({ specs }) =>
     select({
       message: 'Which feature do you want a task breakdown for?',
       choices: specs.map((s) => ({
-        name: s.hasTasks ? `${s.slug}  (tasks.md exists — will overwrite)` : s.slug,
+        name: s.hasTasks
+          ? `${s.slug}  (tasks.md exists — will overwrite)`
+          : s.slug,
         value: s.slug,
       })),
     }),
@@ -46,6 +53,7 @@ export default async function tasksCommand(args = [], deps = {}) {
   const loadConfig = deps.loadConfig ?? defaultLoadConfig;
   const complete = deps.complete ?? defaultComplete;
   const listSpecs = deps.listSpecs ?? defaultListSpecs;
+  const readOverview = deps.readOverview ?? defaultReadOverview;
   const prompts = { ...DEFAULT_PROMPTS, ...(deps.prompts ?? {}) };
 
   const draftwiseDir = join(cwd, '.draftwise');
@@ -54,6 +62,7 @@ export default async function tasksCommand(args = [], deps = {}) {
   }
 
   const config = await loadConfig(cwd);
+  const isGreenfield = config.projectState === 'greenfield';
   const requestedSlug = args[0];
 
   const specs = (await listSpecs(cwd)).filter((s) => s.hasTechnicalSpec);
@@ -87,18 +96,39 @@ export default async function tasksCommand(args = [], deps = {}) {
     );
   }
 
-  log('Scanning repo...');
-  const result = await scan(cwd);
-  if (!result.files || result.files.length === 0) {
-    throw new Error(
-      `No source files found under ${cwd}. Run \`draftwise tasks\` from your repo root.`,
-    );
+  let scanForPrompt;
+  let packageMeta;
+  let overview;
+
+  if (isGreenfield) {
+    log('Reading project plan from overview.md...');
+    overview = await readOverview(cwd);
+    if (!overview.trim()) {
+      throw new Error(
+        'Greenfield project but .draftwise/overview.md is missing or empty. Re-run `draftwise init` to generate the plan.',
+      );
+    }
+    scanForPrompt = null;
+    packageMeta = null;
+  } else {
+    log('Scanning repo...');
+    const result = await scan(cwd);
+    if (!result.files || result.files.length === 0) {
+      throw new Error(
+        `No source files found under ${cwd}. Run \`draftwise tasks\` from your repo root.`,
+      );
+    }
+    scanForPrompt = compactScan(result);
+    packageMeta = result.packageMeta;
   }
-  const scanForPrompt = compactScan(result);
 
   if (config.mode === 'agent') {
     log('');
-    log('Agent mode — handing scanner data + technical spec off to your coding agent.');
+    if (isGreenfield) {
+      log('Agent mode — handing project plan + technical spec off to your coding agent.');
+    } else {
+      log('Agent mode — handing scanner data + technical spec off to your coding agent.');
+    }
     log('');
     log('---');
     log(`SPEC: ${target.slug}`);
@@ -106,18 +136,23 @@ export default async function tasksCommand(args = [], deps = {}) {
     log('TECHNICAL SPEC');
     log(technicalSpec);
     log('');
-    log('SCANNER OUTPUT');
-    log('```json');
-    log(JSON.stringify(scanForPrompt, null, 2));
-    log('```');
-    log('');
-    log('PACKAGE METADATA');
-    log('```json');
-    log(JSON.stringify(result.packageMeta, null, 2));
-    log('```');
+    if (isGreenfield) {
+      log('PROJECT PLAN (overview.md)');
+      log(overview);
+    } else {
+      log('SCANNER OUTPUT');
+      log('```json');
+      log(JSON.stringify(scanForPrompt, null, 2));
+      log('```');
+      log('');
+      log('PACKAGE METADATA');
+      log('```json');
+      log(JSON.stringify(packageMeta, null, 2));
+      log('```');
+    }
     log('');
     log('INSTRUCTION');
-    log(buildAgentInstruction(target.slug));
+    log(buildAgentInstruction(target.slug, config.projectState));
     return;
   }
 
@@ -126,11 +161,13 @@ export default async function tasksCommand(args = [], deps = {}) {
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
     model: config.model,
-    system: SYSTEM,
+    system: selectSystem(config.projectState),
     prompt: buildPrompt({
       technicalSpec,
       scan: scanForPrompt,
-      packageMeta: result.packageMeta,
+      packageMeta,
+      projectState: config.projectState,
+      overview,
     }),
   });
 

--- a/src/commands/tech.js
+++ b/src/commands/tech.js
@@ -5,14 +5,21 @@ import { scan as defaultScan } from '../core/scanner.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { listSpecs as defaultListSpecs } from '../utils/specs.js';
-import { SYSTEM, buildPrompt, buildAgentInstruction } from '../ai/prompts/tech.js';
+import { readOverview as defaultReadOverview } from '../utils/overview.js';
+import {
+  selectSystem,
+  buildPrompt,
+  buildAgentInstruction,
+} from '../ai/prompts/tech.js';
 
 const DEFAULT_PROMPTS = {
   pickSpec: ({ specs }) =>
     select({
       message: 'Which feature spec do you want a technical spec for?',
       choices: specs.map((s) => ({
-        name: s.hasTechnicalSpec ? `${s.slug}  (technical-spec.md exists — will overwrite)` : s.slug,
+        name: s.hasTechnicalSpec
+          ? `${s.slug}  (technical-spec.md exists — will overwrite)`
+          : s.slug,
         value: s.slug,
       })),
     }),
@@ -46,6 +53,7 @@ export default async function techCommand(args = [], deps = {}) {
   const loadConfig = deps.loadConfig ?? defaultLoadConfig;
   const complete = deps.complete ?? defaultComplete;
   const listSpecs = deps.listSpecs ?? defaultListSpecs;
+  const readOverview = deps.readOverview ?? defaultReadOverview;
   const prompts = { ...DEFAULT_PROMPTS, ...(deps.prompts ?? {}) };
 
   const draftwiseDir = join(cwd, '.draftwise');
@@ -54,6 +62,7 @@ export default async function techCommand(args = [], deps = {}) {
   }
 
   const config = await loadConfig(cwd);
+  const isGreenfield = config.projectState === 'greenfield';
   const requestedSlug = args[0];
 
   const specs = (await listSpecs(cwd)).filter((s) => s.hasProductSpec);
@@ -87,18 +96,39 @@ export default async function techCommand(args = [], deps = {}) {
     );
   }
 
-  log('Scanning repo...');
-  const result = await scan(cwd);
-  if (!result.files || result.files.length === 0) {
-    throw new Error(
-      `No source files found under ${cwd}. Run \`draftwise tech\` from your repo root.`,
-    );
+  let scanForPrompt;
+  let packageMeta;
+  let overview;
+
+  if (isGreenfield) {
+    log('Reading project plan from overview.md...');
+    overview = await readOverview(cwd);
+    if (!overview.trim()) {
+      throw new Error(
+        'Greenfield project but .draftwise/overview.md is missing or empty. Re-run `draftwise init` to generate the plan.',
+      );
+    }
+    scanForPrompt = null;
+    packageMeta = null;
+  } else {
+    log('Scanning repo...');
+    const result = await scan(cwd);
+    if (!result.files || result.files.length === 0) {
+      throw new Error(
+        `No source files found under ${cwd}. Run \`draftwise tech\` from your repo root.`,
+      );
+    }
+    scanForPrompt = compactScan(result);
+    packageMeta = result.packageMeta;
   }
-  const scanForPrompt = compactScan(result);
 
   if (config.mode === 'agent') {
     log('');
-    log('Agent mode — handing scanner data + product spec off to your coding agent.');
+    if (isGreenfield) {
+      log('Agent mode — handing project plan + product spec off to your coding agent.');
+    } else {
+      log('Agent mode — handing scanner data + product spec off to your coding agent.');
+    }
     log('');
     log('---');
     log(`SPEC: ${target.slug}`);
@@ -106,18 +136,23 @@ export default async function techCommand(args = [], deps = {}) {
     log('PRODUCT SPEC');
     log(productSpec);
     log('');
-    log('SCANNER OUTPUT');
-    log('```json');
-    log(JSON.stringify(scanForPrompt, null, 2));
-    log('```');
-    log('');
-    log('PACKAGE METADATA');
-    log('```json');
-    log(JSON.stringify(result.packageMeta, null, 2));
-    log('```');
+    if (isGreenfield) {
+      log('PROJECT PLAN (overview.md)');
+      log(overview);
+    } else {
+      log('SCANNER OUTPUT');
+      log('```json');
+      log(JSON.stringify(scanForPrompt, null, 2));
+      log('```');
+      log('');
+      log('PACKAGE METADATA');
+      log('```json');
+      log(JSON.stringify(packageMeta, null, 2));
+      log('```');
+    }
     log('');
     log('INSTRUCTION');
-    log(buildAgentInstruction(target.slug));
+    log(buildAgentInstruction(target.slug, config.projectState));
     return;
   }
 
@@ -126,16 +161,20 @@ export default async function techCommand(args = [], deps = {}) {
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
     model: config.model,
-    system: SYSTEM,
+    system: selectSystem(config.projectState),
     prompt: buildPrompt({
       productSpec,
       scan: scanForPrompt,
-      packageMeta: result.packageMeta,
+      packageMeta,
+      projectState: config.projectState,
+      overview,
     }),
   });
 
   await writeFile(target.technicalSpec, techSpec, 'utf8');
   log('');
   log(`Wrote .draftwise/specs/${target.slug}/technical-spec.md`);
-  log('Next: review, refine, then run `draftwise tasks` to break it into work items.');
+  log(
+    'Next: review, refine, then run `draftwise tasks` to break it into work items.',
+  );
 }

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -4,6 +4,7 @@ import { parse as parseYaml } from 'yaml';
 
 const VALID_MODES = new Set(['agent', 'api']);
 const VALID_PROVIDERS = new Set(['claude', 'openai', 'gemini']);
+const VALID_PROJECT_STATES = new Set(['greenfield', 'brownfield']);
 
 export async function loadConfig(cwd = process.cwd()) {
   const path = join(cwd, '.draftwise', 'config.yaml');
@@ -43,10 +44,17 @@ export async function loadConfig(cwd = process.cwd()) {
     }
   }
 
+  const project = parsed?.project ?? {};
+  const projectState = VALID_PROJECT_STATES.has(project.state)
+    ? project.state
+    : 'brownfield';
+
   return {
     mode: ai.mode,
     provider: ai.provider,
     apiKeyEnv: ai.api_key_env,
     model: ai.model || '',
+    projectState,
+    stack: project.stack,
   };
 }

--- a/src/utils/overview.js
+++ b/src/utils/overview.js
@@ -1,0 +1,10 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export async function readOverview(cwd) {
+  try {
+    return await readFile(join(cwd, '.draftwise', 'overview.md'), 'utf8');
+  } catch {
+    return '';
+  }
+}

--- a/test/commands/explain.test.js
+++ b/test/commands/explain.test.js
@@ -121,6 +121,24 @@ describe('draftwise explain', () => {
     expect(logs.join('\n')).toContain('# Flow: login');
   });
 
+  it('short-circuits in greenfield mode with a friendly message', async () => {
+    let scanCalled = false;
+    await explainCommand(['login'], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => {
+        scanCalled = true;
+        return SAMPLE_SCAN;
+      },
+      loadConfig: async () => ({ mode: 'agent', projectState: 'greenfield' }),
+      complete: async () => {
+        throw new Error('should not be called in greenfield');
+      },
+    });
+    expect(scanCalled).toBe(false);
+    expect(logs.join('\n')).toContain('No code yet');
+  });
+
   it('errors when the scan returns zero files', async () => {
     await expect(
       explainCommand(['login'], {

--- a/test/commands/new.test.js
+++ b/test/commands/new.test.js
@@ -190,4 +190,95 @@ describe('draftwise new', () => {
     );
     expect(spec).toContain('# Spec');
   });
+
+  it('greenfield api mode: skips scanner, reads overview, calls greenfield prompts', async () => {
+    let scanCalled = false;
+    let callCount = 0;
+    const captured = [];
+
+    const greenfieldPlan = {
+      feature_slug: 'recipe-uploads',
+      feature_title: 'Recipe Uploads',
+      clarifying_questions: [
+        { text: 'Photos required?', why: 'data model decision' },
+      ],
+    };
+
+    await newCommand(['add', 'recipe', 'uploads'], {
+      cwd: dir,
+      log: () => {},
+      scan: async () => {
+        scanCalled = true;
+        return SAMPLE_SCAN;
+      },
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+        projectState: 'greenfield',
+      }),
+      readOverview: async () => '# Recipe app — Greenfield plan\n\nNext.js + Postgres + Prisma\n',
+      complete: async (req) => {
+        callCount++;
+        captured.push(req);
+        if (callCount === 1) return JSON.stringify(greenfieldPlan);
+        return '# Recipe Uploads\n\nGreenfield spec body.';
+      },
+      prompts: fakePrompts({ answers: ['Yes'], decisions: [] }),
+    });
+
+    expect(scanCalled).toBe(false);
+    expect(callCount).toBe(2);
+    expect(captured[0].system).toContain('GREENFIELD');
+    expect(captured[0].prompt).toContain('Recipe app');
+    expect(captured[1].system).toContain('GREENFIELD');
+    expect(captured[1].prompt).not.toContain('"affected_flows"');
+
+    const spec = await readFile(
+      join(dir, '.draftwise', 'specs', 'recipe-uploads', 'product-spec.md'),
+      'utf8',
+    );
+    expect(spec).toContain('# Recipe Uploads');
+  });
+
+  it('greenfield agent mode: dumps PROJECT PLAN instead of SCANNER OUTPUT', async () => {
+    const localLogs = [];
+    await newCommand(['recipe', 'app'], {
+      cwd: dir,
+      log: (m) => localLogs.push(m),
+      scan: async () => {
+        throw new Error('scan should not be called in greenfield');
+      },
+      loadConfig: async () => ({
+        mode: 'agent',
+        projectState: 'greenfield',
+      }),
+      readOverview: async () => '# Recipe app — Greenfield plan\n',
+      complete: async () => {
+        throw new Error('complete should not be called in agent mode');
+      },
+    });
+
+    const out = localLogs.join('\n');
+    expect(out).toContain('PROJECT PLAN');
+    expect(out).not.toContain('SCANNER OUTPUT');
+    expect(out).toContain('Recipe app');
+  });
+
+  it('greenfield: errors if overview.md is empty', async () => {
+    await expect(
+      newCommand(['feature'], {
+        cwd: dir,
+        log: () => {},
+        scan: async () => SAMPLE_SCAN,
+        loadConfig: async () => ({
+          mode: 'agent',
+          projectState: 'greenfield',
+        }),
+        readOverview: async () => '',
+        complete: async () => '',
+      }),
+    ).rejects.toThrow(/overview\.md is missing or empty/);
+  });
 });

--- a/test/commands/scan.test.js
+++ b/test/commands/scan.test.js
@@ -87,6 +87,27 @@ describe('draftwise scan', () => {
     expect(overview).toContain('# Overview');
   });
 
+  it('short-circuits in greenfield mode with a friendly message', async () => {
+    let scanCalled = false;
+    await scanCommand([], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      scan: async () => {
+        scanCalled = true;
+        return SAMPLE_SCAN;
+      },
+      loadConfig: async () => ({ mode: 'agent', projectState: 'greenfield' }),
+      complete: async () => {
+        throw new Error('should not be called in greenfield');
+      },
+    });
+
+    expect(scanCalled).toBe(false);
+    const out = logs.join('\n');
+    expect(out).toContain('No code yet');
+    expect(out).toContain('greenfield plan');
+  });
+
   it('errors when scan returns zero files', async () => {
     await expect(
       scanCommand([], {

--- a/test/commands/tasks.test.js
+++ b/test/commands/tasks.test.js
@@ -202,4 +202,68 @@ describe('draftwise tasks', () => {
       }),
     ).rejects.toThrow(/empty/);
   });
+
+  it('greenfield: skips scanner, reads overview, uses greenfield prompts', async () => {
+    await seedSpec(dir, 'collab-albums', { technical: '# Tech\n\nGreenfield.' });
+
+    let scanCalled = false;
+    let captured;
+
+    await tasksCommand([], {
+      cwd: dir,
+      log: () => {},
+      scan: async () => {
+        scanCalled = true;
+        return SAMPLE_SCAN;
+      },
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+        projectState: 'greenfield',
+      }),
+      readOverview: async () => '# Plan\n\nNext.js + Prisma\n',
+      complete: async (req) => {
+        captured = req;
+        return '# Tasks\n\n1. Scaffold project';
+      },
+    });
+
+    expect(scanCalled).toBe(false);
+    expect(captured.system).toContain('GREENFIELD');
+    expect(captured.prompt).toContain('Plan');
+    expect(captured.prompt).not.toContain('"frameworks"');
+
+    const tasks = await readFile(
+      join(dir, '.draftwise', 'specs', 'collab-albums', 'tasks.md'),
+      'utf8',
+    );
+    expect(tasks).toContain('Scaffold project');
+  });
+
+  it('greenfield agent mode: dumps PROJECT PLAN instead of SCANNER OUTPUT', async () => {
+    await seedSpec(dir, 'collab-albums', { technical: '# Tech' });
+
+    const localLogs = [];
+    await tasksCommand([], {
+      cwd: dir,
+      log: (m) => localLogs.push(m),
+      scan: async () => {
+        throw new Error('should not be called in greenfield agent mode');
+      },
+      loadConfig: async () => ({
+        mode: 'agent',
+        projectState: 'greenfield',
+      }),
+      readOverview: async () => '# Plan\n\nNext.js + Prisma\n',
+      complete: async () => {
+        throw new Error('should not be called in agent mode');
+      },
+    });
+
+    const out = localLogs.join('\n');
+    expect(out).toContain('PROJECT PLAN');
+    expect(out).not.toContain('SCANNER OUTPUT');
+  });
 });

--- a/test/commands/tech.test.js
+++ b/test/commands/tech.test.js
@@ -196,4 +196,68 @@ describe('draftwise tech', () => {
       }),
     ).rejects.toThrow(/empty/);
   });
+
+  it('greenfield: skips scanner, reads overview, uses greenfield prompts', async () => {
+    await seedSpec(dir, 'collab-albums', '# Product\n\nGreenfield product.');
+
+    let scanCalled = false;
+    let captured;
+
+    await techCommand([], {
+      cwd: dir,
+      log: () => {},
+      scan: async () => {
+        scanCalled = true;
+        return SAMPLE_SCAN;
+      },
+      loadConfig: async () => ({
+        mode: 'api',
+        provider: 'claude',
+        apiKeyEnv: 'ANTHROPIC_API_KEY',
+        model: '',
+        projectState: 'greenfield',
+      }),
+      readOverview: async () => '# Plan\n\nNext.js + Prisma\n',
+      complete: async (req) => {
+        captured = req;
+        return '# Tech\n\nWith (new) markers.';
+      },
+    });
+
+    expect(scanCalled).toBe(false);
+    expect(captured.system).toContain('GREENFIELD');
+    expect(captured.prompt).toContain('Plan');
+    expect(captured.prompt).not.toContain('"frameworks"');
+
+    const tech = await readFile(
+      join(dir, '.draftwise', 'specs', 'collab-albums', 'technical-spec.md'),
+      'utf8',
+    );
+    expect(tech).toContain('# Tech');
+  });
+
+  it('greenfield agent mode: dumps PROJECT PLAN instead of SCANNER OUTPUT', async () => {
+    await seedSpec(dir, 'collab-albums', '# Product');
+
+    const localLogs = [];
+    await techCommand([], {
+      cwd: dir,
+      log: (m) => localLogs.push(m),
+      scan: async () => {
+        throw new Error('should not be called in greenfield agent mode');
+      },
+      loadConfig: async () => ({
+        mode: 'agent',
+        projectState: 'greenfield',
+      }),
+      readOverview: async () => '# Plan\n\nNext.js + Prisma\n',
+      complete: async () => {
+        throw new Error('should not be called in agent mode');
+      },
+    });
+
+    const out = localLogs.join('\n');
+    expect(out).toContain('PROJECT PLAN');
+    expect(out).not.toContain('SCANNER OUTPUT');
+  });
 });

--- a/test/utils/config.test.js
+++ b/test/utils/config.test.js
@@ -28,7 +28,30 @@ describe('loadConfig', () => {
       provider: undefined,
       apiKeyEnv: undefined,
       model: '',
+      projectState: 'brownfield',
+      stack: undefined,
     });
+  });
+
+  it('reads project state and stack when present', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: agent\nproject:\n  state: greenfield\n  stack: "Next.js + Postgres + Prisma"\n',
+      'utf8',
+    );
+    const config = await loadConfig(dir);
+    expect(config.projectState).toBe('greenfield');
+    expect(config.stack).toBe('Next.js + Postgres + Prisma');
+  });
+
+  it('defaults projectState to brownfield when missing (back-compat with v0.0.1 configs)', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: agent\n',
+      'utf8',
+    );
+    const config = await loadConfig(dir);
+    expect(config.projectState).toBe('brownfield');
   });
 
   it('reads api mode config with provider and api_key_env', async () => {


### PR DESCRIPTION
…efully

config.yaml's project.state (set by init in the prior PR) now drives prompt routing across every downstream command. Default is brownfield, so configs written before greenfield routing landed keep working unchanged.

Per command:

scan / explain (brownfield-only by nature) — short-circuit in greenfield with a friendly message pointing at the greenfield plan in overview.md. No scan call, no error, exit 0.

new — greenfield path skips the scanner, reads overview.md as context, and uses a different system prompt that asks for clarifying questions only (no affected_flows or adjacent_ opportunities — there are no existing flows yet). The synthesis prompt drops "Affected flows" and "Adjacent changes" sections from the spec.

tech — greenfield path reads overview.md, drops the "every file must come from scanner" hard rule, and instructs the model to mark every file path "(new)" while matching the chosen stack's conventions (Prisma syntax, Next App Router files, etc.).

tasks — greenfield path requires the first 1-3 tasks to be foundational scaffolding (run setup commands, install deps, configure env). Every file path is "(new)".

Each prompt module now exports SYSTEM_BROWNFIELD + SYSTEM_GREENFIELD constants (with the original SYSTEM kept as a back-compat alias) plus a selectSystem(projectState) helper. buildPrompt and buildAgentInstruction branch on projectState. The new src/utils/ overview.js helper reads .draftwise/overview.md for greenfield context.

9 new tests across config, scan, explain, new, tech, tasks. 95 total, all passing.

Per docs-sync: README roadmap items checked off (greenfield-aware new/tech/tasks now done); CLAUDE.md v1 status section updated with explicit per-command greenfield behavior; config.yaml example in CLAUDE.md now shows the project section.