### PR TITLE
Cap scanner file count and warn on missing framework detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ ai:
 project:
   state: greenfield | brownfield      # set by `draftwise init`; controls prompt routing
   stack: "Next.js + Postgres + Prisma" # greenfield only; the stack the PM picked at init
+scan:
+  max_files: 5000                      # optional; raise for monorepos. Scanner emits a "truncated" warning when this is hit.
 ```
 
 `loadConfig()` in `src/utils/config.js` defaults `project.state` to `brownfield` for back-compat with configs written before the greenfield routing landed.
@@ -265,11 +267,10 @@ When a contributor proposes one of these, gently redirect — they're worth doin
 
 ## Open questions (post-v1)
 
-Some originals have been answered by implementation; the remaining ones are real and worth revisiting before `0.1.0`:
-
-1. **Scan depth.** Today the scanner walks the whole tree (skipping `node_modules`/build dirs/dotfiles) and skips files >200KB during route-regex scanning. No hard file cap. May need one for monorepos.
-2. **Scan caching.** Today every command re-runs the scanner — no caching, no incremental updates. Cheap enough for now but a bottleneck on huge repos.
-3. **Default model.** `claude-sonnet-4-6` is hardcoded in `src/ai/providers/claude.js` as the default; users can override via `ai.model` in `config.yaml`. Reasonable for now.
+1. ~~**Scan depth.**~~ ✅ Resolved. Scanner now caps at `DEFAULT_MAX_FILES` (5000) by default; users can raise via `scan.max_files` in `config.yaml`. When the cap is hit, scan results carry `truncated: true` and commands surface a warning pointing at the config knob.
+2. **Scan caching.** Today every command re-runs the scanner — no caching, no incremental updates. Cheap enough for typical repos but a bottleneck on huge ones. Worth tackling alongside flow-aware filtering for `explain`.
+3. **Default model.** `claude-sonnet-4-6` hardcoded in `src/ai/providers/claude.js` as the default; users can override via `ai.model` in `config.yaml`. Reasonable for now.
 4. **Large flow tracing.** `explain` sends the full scanner output to the model regardless of flow size. May need flow-aware filtering (only include relevant files) for very large flows.
-5. **Unsupported frameworks.** Scanner returns empty arrays for routes/components/models when nothing matches — graceful but silent. Should it warn the user explicitly?
+5. ~~**Unsupported frameworks.**~~ ✅ Resolved. `init` and `scan` now log an explicit "no framework detected" hint when the scanner returns an empty `frameworks` array, listing what's supported.
 6. **OpenAI / Gemini adapters.** Stubbed with a clear error in `src/ai/provider.js`. Wire up when a user asks for them.
+7. **Scanner language coverage.** v1 covers JS/TS frameworks + JS/TS-native ORMs. Python (FastAPI/Django/Flask + SQLAlchemy/Django ORM) is the next planned expansion.

--- a/src/commands/explain.js
+++ b/src/commands/explain.js
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { scan as defaultScan } from '../core/scanner.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
+import { describeScanWarnings } from '../utils/scan-warnings.js';
 import { SYSTEM, buildPrompt, buildAgentInstruction } from '../ai/prompts/explain.js';
 import { slugify } from '../utils/slug.js';
 
@@ -59,7 +60,10 @@ export default async function explainCommand(args = [], deps = {}) {
   const slug = slugify(flow);
 
   log(`Tracing "${flow}"...`);
-  const result = await scan(cwd);
+  const result = await scan(cwd, { maxFiles: config.scanMaxFiles });
+  for (const warning of describeScanWarnings(result)) {
+    log(warning);
+  }
 
   if (!result.files || result.files.length === 0) {
     throw new Error(

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -4,6 +4,7 @@ import { stringify as yamlStringify } from 'yaml';
 import { select, input } from '@inquirer/prompts';
 import { scan as defaultScan } from '../core/scanner.js';
 import { complete as defaultComplete } from '../ai/provider.js';
+import { describeScanWarnings } from '../utils/scan-warnings.js';
 import {
   QUESTIONS_SYSTEM,
   STACKS_SYSTEM,
@@ -178,6 +179,11 @@ async function runBrownfield({ cwd, log, scan, draftwiseDir, aiConfig }) {
   log(
     `Found ${result.files.length} source file${result.files.length === 1 ? '' : 's'}.`,
   );
+  for (const warning of describeScanWarnings(result, {
+    includeFrameworkHint: true,
+  })) {
+    log(warning);
+  }
   log('');
 
   await mkdir(join(draftwiseDir, 'specs'), { recursive: true });

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -5,6 +5,7 @@ import { scan as defaultScan } from '../core/scanner.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { readOverview as defaultReadOverview } from '../utils/overview.js';
+import { describeScanWarnings } from '../utils/scan-warnings.js';
 import {
   selectPlanSystem,
   selectSpecSystem,
@@ -93,11 +94,14 @@ export default async function newCommand(args = [], deps = {}) {
     packageMeta = null;
   } else {
     log('Scanning repo...');
-    const result = await scan(cwd);
+    const result = await scan(cwd, { maxFiles: config.scanMaxFiles });
     if (!result.files || result.files.length === 0) {
       throw new Error(
         `No source files found under ${cwd}. Run \`draftwise new\` from your repo root.`,
       );
+    }
+    for (const warning of describeScanWarnings(result)) {
+      log(warning);
     }
     scanForPrompt = compactScan(result);
     packageMeta = result.packageMeta;

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { scan as defaultScan } from '../core/scanner.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
+import { describeScanWarnings } from '../utils/scan-warnings.js';
 import { SYSTEM, buildPrompt, AGENT_INSTRUCTION } from '../ai/prompts/scan.js';
 
 async function pathExists(p) {
@@ -53,7 +54,7 @@ export default async function scanCommand(_args = [], deps = {}) {
   }
 
   log('Scanning repo...');
-  const result = await scan(cwd);
+  const result = await scan(cwd, { maxFiles: config.scanMaxFiles });
 
   if (!result.files || result.files.length === 0) {
     throw new Error(
@@ -65,6 +66,11 @@ export default async function scanCommand(_args = [], deps = {}) {
   log(
     `  ${summary.files} files · ${summary.frameworks.join(', ') || 'no framework detected'} · ${summary.routes} routes · ${summary.components} components · ${summary.models} models`,
   );
+  for (const warning of describeScanWarnings(result, {
+    includeFrameworkHint: true,
+  })) {
+    log(warning);
+  }
   log('');
 
   const scanForPrompt = {

--- a/src/commands/tasks.js
+++ b/src/commands/tasks.js
@@ -6,6 +6,7 @@ import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { listSpecs as defaultListSpecs } from '../utils/specs.js';
 import { readOverview as defaultReadOverview } from '../utils/overview.js';
+import { describeScanWarnings } from '../utils/scan-warnings.js';
 import {
   selectSystem,
   buildPrompt,
@@ -112,11 +113,14 @@ export default async function tasksCommand(args = [], deps = {}) {
     packageMeta = null;
   } else {
     log('Scanning repo...');
-    const result = await scan(cwd);
+    const result = await scan(cwd, { maxFiles: config.scanMaxFiles });
     if (!result.files || result.files.length === 0) {
       throw new Error(
         `No source files found under ${cwd}. Run \`draftwise tasks\` from your repo root.`,
       );
+    }
+    for (const warning of describeScanWarnings(result)) {
+      log(warning);
     }
     scanForPrompt = compactScan(result);
     packageMeta = result.packageMeta;

--- a/src/commands/tech.js
+++ b/src/commands/tech.js
@@ -6,6 +6,7 @@ import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { listSpecs as defaultListSpecs } from '../utils/specs.js';
 import { readOverview as defaultReadOverview } from '../utils/overview.js';
+import { describeScanWarnings } from '../utils/scan-warnings.js';
 import {
   selectSystem,
   buildPrompt,
@@ -112,11 +113,14 @@ export default async function techCommand(args = [], deps = {}) {
     packageMeta = null;
   } else {
     log('Scanning repo...');
-    const result = await scan(cwd);
+    const result = await scan(cwd, { maxFiles: config.scanMaxFiles });
     if (!result.files || result.files.length === 0) {
       throw new Error(
         `No source files found under ${cwd}. Run \`draftwise tech\` from your repo root.`,
       );
+    }
+    for (const warning of describeScanWarnings(result)) {
+      log(warning);
     }
     scanForPrompt = compactScan(result);
     packageMeta = result.packageMeta;

--- a/src/core/scanner.js
+++ b/src/core/scanner.js
@@ -60,9 +60,13 @@ const ORM_DEPS = {
   knex: 'Knex',
 };
 
-export async function scan(root) {
+export const DEFAULT_MAX_FILES = 5000;
+
+export async function scan(root, options = {}) {
+  const maxFiles = options.maxFiles ?? DEFAULT_MAX_FILES;
   const files = [];
-  await walk(root, root, files);
+  const state = { count: 0, max: maxFiles, truncated: false };
+  await walk(root, root, files, state);
 
   const packageMeta = await readPackageJson(root);
   const frameworks = detectFrameworks(packageMeta);
@@ -84,10 +88,13 @@ export async function scan(root) {
     routes,
     components,
     models,
+    truncated: state.truncated,
+    maxFiles,
   };
 }
 
-async function walk(root, dir, out) {
+async function walk(root, dir, out, state) {
+  if (state.truncated) return;
   let entries;
   try {
     entries = await readdir(dir, { withFileTypes: true });
@@ -95,14 +102,20 @@ async function walk(root, dir, out) {
     return;
   }
   for (const entry of entries) {
+    if (state.truncated) return;
     if (IGNORE_DIRS.has(entry.name)) continue;
     if (entry.name.startsWith('.')) continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) {
-      await walk(root, full, out);
+      await walk(root, full, out, state);
     } else if (entry.isFile()) {
       if (CODE_EXTENSIONS.has(extOf(entry.name))) {
+        if (state.count >= state.max) {
+          state.truncated = true;
+          return;
+        }
         out.push(toPosix(relative(root, full)));
+        state.count++;
       }
     }
   }

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -49,6 +49,12 @@ export async function loadConfig(cwd = process.cwd()) {
     ? project.state
     : 'brownfield';
 
+  const scan = parsed?.scan ?? {};
+  let scanMaxFiles;
+  if (typeof scan.max_files === 'number' && Number.isFinite(scan.max_files)) {
+    scanMaxFiles = Math.max(1, Math.floor(scan.max_files));
+  }
+
   return {
     mode: ai.mode,
     provider: ai.provider,
@@ -56,5 +62,6 @@ export async function loadConfig(cwd = process.cwd()) {
     model: ai.model || '',
     projectState,
     stack: project.stack,
+    scanMaxFiles,
   };
 }

--- a/src/utils/scan-warnings.js
+++ b/src/utils/scan-warnings.js
@@ -1,0 +1,14 @@
+export function describeScanWarnings(scan, { includeFrameworkHint = false } = {}) {
+  const warnings = [];
+  if (scan?.truncated) {
+    warnings.push(
+      `Note: scanner stopped at ${scan.maxFiles} source files. Raise \`scan.max_files\` in .draftwise/config.yaml for fuller coverage.`,
+    );
+  }
+  if (includeFrameworkHint && (scan?.frameworks?.length ?? 0) === 0) {
+    warnings.push(
+      "Heads up: no framework detected. Draftwise's scanner supports JS/TS (Next.js, Express, Fastify, Vue, Svelte) and common ORMs (Prisma, Mongoose, Drizzle). Other languages will produce shallow scans until language-specific support lands.",
+    );
+  }
+  return warnings;
+}

--- a/test/core/scanner.test.js
+++ b/test/core/scanner.test.js
@@ -114,6 +114,30 @@ model Post {
     expect(user.fields).toContain('email');
   });
 
+  it('caps files at maxFiles and sets truncated', async () => {
+    const fixture = { 'package.json': '{}' };
+    for (let i = 0; i < 10; i++) {
+      fixture[`src/file${i}.js`] = `// ${i}`;
+    }
+    await writeFixture(dir, fixture);
+
+    const result = await scan(dir, { maxFiles: 5 });
+    expect(result.files.length).toBe(5);
+    expect(result.truncated).toBe(true);
+    expect(result.maxFiles).toBe(5);
+  });
+
+  it('does not flag truncated when within the cap', async () => {
+    await writeFixture(dir, {
+      'package.json': '{}',
+      'src/a.js': '//',
+      'src/b.js': '//',
+    });
+    const result = await scan(dir, { maxFiles: 100 });
+    expect(result.truncated).toBe(false);
+    expect(result.files).toHaveLength(2);
+  });
+
   it('ignores node_modules and .git', async () => {
     await writeFixture(dir, {
       'package.json': '{}',

--- a/test/utils/config.test.js
+++ b/test/utils/config.test.js
@@ -54,6 +54,36 @@ describe('loadConfig', () => {
     expect(config.projectState).toBe('brownfield');
   });
 
+  it('parses scan.max_files when set', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: agent\nscan:\n  max_files: 10000\n',
+      'utf8',
+    );
+    const config = await loadConfig(dir);
+    expect(config.scanMaxFiles).toBe(10000);
+  });
+
+  it('leaves scanMaxFiles undefined when not set (scanner uses its default)', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: agent\n',
+      'utf8',
+    );
+    const config = await loadConfig(dir);
+    expect(config.scanMaxFiles).toBeUndefined();
+  });
+
+  it('coerces scan.max_files to a positive integer', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: agent\nscan:\n  max_files: 250.7\n',
+      'utf8',
+    );
+    const config = await loadConfig(dir);
+    expect(config.scanMaxFiles).toBe(250);
+  });
+
   it('reads api mode config with provider and api_key_env', async () => {
     await writeFile(
       join(dir, '.draftwise', 'config.yaml'),

--- a/test/utils/scan-warnings.test.js
+++ b/test/utils/scan-warnings.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { describeScanWarnings } from '../../src/utils/scan-warnings.js';
+
+describe('describeScanWarnings', () => {
+  it('returns no warnings for a healthy scan', () => {
+    expect(
+      describeScanWarnings({
+        truncated: false,
+        frameworks: ['Next.js'],
+      }),
+    ).toEqual([]);
+  });
+
+  it('warns when the scan was truncated', () => {
+    const warnings = describeScanWarnings({
+      truncated: true,
+      maxFiles: 5000,
+      frameworks: ['Next.js'],
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('5000');
+    expect(warnings[0]).toContain('scan.max_files');
+  });
+
+  it('warns about no framework only when includeFrameworkHint is set', () => {
+    const without = describeScanWarnings({
+      truncated: false,
+      frameworks: [],
+    });
+    expect(without).toEqual([]);
+
+    const withHint = describeScanWarnings(
+      { truncated: false, frameworks: [] },
+      { includeFrameworkHint: true },
+    );
+    expect(withHint).toHaveLength(1);
+    expect(withHint[0]).toContain('no framework detected');
+  });
+
+  it('combines truncation and framework warnings when both apply', () => {
+    const warnings = describeScanWarnings(
+      { truncated: true, maxFiles: 100, frameworks: [] },
+      { includeFrameworkHint: true },
+    );
+    expect(warnings).toHaveLength(2);
+  });
+
+  it('handles a missing scan gracefully', () => {
+    expect(describeScanWarnings(undefined)).toEqual([]);
+    expect(describeScanWarnings({})).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes two of the open questions in CLAUDE.md (Q1 and Q5).

Scanner gains a configurable file cap (DEFAULT_MAX_FILES = 5000) to protect against runaway walks in monorepos. The scan() function now accepts { maxFiles } and stops walking once the cap is hit, returning the truncated flag and the cap that was applied. Walk respects the flag mid-recursion to avoid extra work.

config.yaml gains an optional scan section:

    scan:
      max_files: 10000

loadConfig parses scan.max_files into config.scanMaxFiles (coerced to a positive integer). Each command that calls the scanner now passes config.scanMaxFiles through to scan().

Two warnings via the new src/utils/scan-warnings.js helper:

- "Note: scanner stopped at N source files. Raise scan.max_files in .draftwise/config.yaml for fuller coverage." — surfaced in every command that invokes the scanner whenever truncated is true.

- "Heads up: no framework detected. Draftwise's scanner supports JS/TS (Next.js, Express, Fastify, Vue, Svelte) and common ORMs (Prisma, Mongoose, Drizzle). Other languages will produce shallow scans until language-specific support lands." — only surfaced in init (brownfield) and scan, since those are the natural moments to recalibrate expectations.

10 new tests across scanner, config, and the warnings helper. 112 total, all passing.

Per docs-sync: CLAUDE.md config.yaml example shows the new scan section; open questions list marks Q1 and Q5 as resolved and adds a new Q7 noting Python is the next planned scanner expansion.