### PR TITLE
Expand scanner to Python — FastAPI / Flask / Django + SQLAlchemy / Dj…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,9 +198,11 @@ A structured JSON-ish object that any command can consume:
 
 ### Languages and frameworks
 
-**v1 supports:** JS/TS Node projects (Express, Next.js), common ORM patterns.
+**Currently supported:**
+- **JS/TS:** Next.js (pages + app router), Express, Fastify, Hapi, Koa, NestJS, Vue, Svelte, SvelteKit, Nuxt, Remix, React Router. ORMs: Prisma, Mongoose, Sequelize, Drizzle, TypeORM, Knex.
+- **Python:** FastAPI, Starlette, Flask, Django, Tornado. ORMs: SQLAlchemy, Django ORM, Peewee, Tortoise ORM. Reads `requirements.txt` and `pyproject.toml` (PEP 621 + Poetry tables).
 
-**v2+ ambitions:** Python (FastAPI, Django), Rust, Go, mobile codebases (React Native, Swift, Kotlin).
+**Planned expansions:** Go (net/http, Gin, Echo, Chi + GORM, Ent), Rust (Axum, Actix, Rocket + Diesel, sqlx), mobile codebases (React Native, Swift, Kotlin).
 
 Don't try to make v1 universal. A great experience for JS/TS is better than a mediocre experience for everything.
 
@@ -273,4 +275,4 @@ When a contributor proposes one of these, gently redirect — they're worth doin
 4. **Large flow tracing.** `explain` sends the full scanner output to the model regardless of flow size. May need flow-aware filtering (only include relevant files) for very large flows.
 5. ~~**Unsupported frameworks.**~~ ✅ Resolved. `init` and `scan` now log an explicit "no framework detected" hint when the scanner returns an empty `frameworks` array, listing what's supported.
 6. **OpenAI / Gemini adapters.** Stubbed with a clear error in `src/ai/provider.js`. Wire up when a user asks for them.
-7. **Scanner language coverage.** v1 covers JS/TS frameworks + JS/TS-native ORMs. Python (FastAPI/Django/Flask + SQLAlchemy/Django ORM) is the next planned expansion.
+7. ~~**Scanner language coverage — Python.**~~ ✅ Resolved. Python support added in PR after `0.0.1`: detects FastAPI / Starlette / Flask / Django / Tornado from `requirements.txt` or `pyproject.toml` (PEP 621 + Poetry), parses FastAPI / Flask decorator-based routes, parses Django `urls.py` `path(...)` / `re_path(...)`, and parses SQLAlchemy + Django ORM models. Test files (`tests/`, `test_*.py`, `_test.py`, `conftest.py`) are excluded from route detection. Go and Rust are the next planned language expansions.

--- a/src/core/scanner.js
+++ b/src/core/scanner.js
@@ -15,6 +15,19 @@ const IGNORE_DIRS = new Set([
   '.cache',
   '.vite',
   '.parcel-cache',
+  // Python
+  '__pycache__',
+  'venv',
+  '.venv',
+  'env',
+  '.env-dir',
+  '.tox',
+  '.pytest_cache',
+  '.mypy_cache',
+  '.ruff_cache',
+  'site-packages',
+  'eggs',
+  '.eggs',
 ]);
 
 const CODE_EXTENSIONS = new Set([
@@ -35,6 +48,7 @@ const CODE_EXTENSIONS = new Set([
 const COMPONENT_EXTENSIONS = new Set(['.jsx', '.tsx', '.vue', '.svelte']);
 
 const FRAMEWORK_DEPS = {
+  // JS / TS
   next: 'Next.js',
   '@remix-run/react': 'Remix',
   'react-router-dom': 'React Router',
@@ -48,9 +62,16 @@ const FRAMEWORK_DEPS = {
   '@hapi/hapi': 'Hapi',
   koa: 'Koa',
   '@nestjs/core': 'NestJS',
+  // Python
+  fastapi: 'FastAPI',
+  starlette: 'Starlette',
+  flask: 'Flask',
+  django: 'Django',
+  tornado: 'Tornado',
 };
 
 const ORM_DEPS = {
+  // JS / TS
   '@prisma/client': 'Prisma',
   prisma: 'Prisma',
   mongoose: 'Mongoose',
@@ -58,7 +79,17 @@ const ORM_DEPS = {
   'drizzle-orm': 'Drizzle',
   typeorm: 'TypeORM',
   knex: 'Knex',
+  // Python
+  sqlalchemy: 'SQLAlchemy',
+  'sqlalchemy-utils': 'SQLAlchemy',
+  alembic: 'SQLAlchemy',
+  django: 'Django ORM',
+  peewee: 'Peewee',
+  'tortoise-orm': 'Tortoise ORM',
 };
+
+const PY_FILE_RE = /\.py$/;
+const PY_TEST_FILE_RE = /(?:^|\/)(?:tests?|__tests__)\/|\/test_|^test_|\/conftest\.py$|_test\.py$/;
 
 export const DEFAULT_MAX_FILES = 5000;
 
@@ -68,7 +99,7 @@ export async function scan(root, options = {}) {
   const state = { count: 0, max: maxFiles, truncated: false };
   await walk(root, root, files, state);
 
-  const packageMeta = await readPackageJson(root);
+  const packageMeta = await readProjectMeta(root);
   const frameworks = detectFrameworks(packageMeta);
   const orms = detectOrms(packageMeta);
 
@@ -76,7 +107,7 @@ export async function scan(root, options = {}) {
     .filter((f) => COMPONENT_EXTENSIONS.has(extOf(f)))
     .map((file) => ({ name: baseName(file), file }));
 
-  const routes = await detectRoutes(root, files);
+  const routes = await detectRoutes(root, files, frameworks);
   const models = await detectModels(root, files, orms);
 
   return {
@@ -137,6 +168,31 @@ function toPosix(p) {
   return p.split(sep).join('/');
 }
 
+async function readProjectMeta(root) {
+  const node = await readPackageJson(root);
+  const py = await readPythonProject(root);
+  if (!node && !py) return null;
+
+  const languages = [];
+  if (node) languages.push('javascript');
+  if (py) languages.push('python');
+
+  return {
+    name: node?.name ?? py?.name,
+    version: node?.version ?? py?.version,
+    description: node?.description ?? py?.description,
+    dependencies: [
+      ...(node?.dependencies ?? []),
+      ...(py?.dependencies ?? []),
+    ],
+    devDependencies: [
+      ...(node?.devDependencies ?? []),
+      ...(py?.devDependencies ?? []),
+    ],
+    languages,
+  };
+}
+
 async function readPackageJson(root) {
   const path = join(root, 'package.json');
   try {
@@ -152,6 +208,175 @@ async function readPackageJson(root) {
   } catch {
     return null;
   }
+}
+
+// Lightweight Python project metadata reader. Tries pyproject.toml first
+// (PEP 621 [project] and Poetry [tool.poetry]), falls back to requirements.txt.
+async function readPythonProject(root) {
+  const pyproject = await tryReadPyproject(root);
+  if (pyproject) return pyproject;
+  const requirements = await tryReadRequirementsTxt(root);
+  if (requirements) return requirements;
+  return null;
+}
+
+async function tryReadPyproject(root) {
+  const path = join(root, 'pyproject.toml');
+  let raw;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+
+  // Minimal TOML parsing — we only need project name, version, description,
+  // and dependency lists. Real TOML parsing is overkill for v1.
+  const sections = parseTomlSections(raw);
+  const project = sections['project'] ?? sections['tool.poetry'] ?? {};
+
+  const deps = [];
+  // PEP 621 dependencies = [...] (array of strings like "fastapi >= 0.100")
+  const depList = parseTomlArrayString(sections['project'], 'dependencies');
+  for (const entry of depList) {
+    const name = pythonRequirementName(entry);
+    if (name) deps.push(name);
+  }
+
+  // Poetry [tool.poetry.dependencies] is a table with package = "version" lines
+  const poetryDeps = sections['tool.poetry.dependencies'] ?? {};
+  for (const key of Object.keys(poetryDeps)) {
+    if (key === 'python') continue;
+    deps.push(key);
+  }
+
+  const devDeps = [];
+  const poetryDev = sections['tool.poetry.dev-dependencies'] ?? sections['tool.poetry.group.dev.dependencies'] ?? {};
+  for (const key of Object.keys(poetryDev)) {
+    devDeps.push(key);
+  }
+
+  // PEP 621 optional-dependencies (e.g. [project.optional-dependencies] dev = [...])
+  const optDevList = parseTomlArrayString(
+    sections['project.optional-dependencies'],
+    'dev',
+  );
+  for (const entry of optDevList) {
+    const name = pythonRequirementName(entry);
+    if (name) devDeps.push(name);
+  }
+
+  if (deps.length === 0 && devDeps.length === 0 && !project.name) return null;
+
+  return {
+    name: project.name,
+    version: project.version,
+    description: project.description,
+    dependencies: [...new Set(deps)],
+    devDependencies: [...new Set(devDeps)],
+  };
+}
+
+async function tryReadRequirementsTxt(root) {
+  const path = join(root, 'requirements.txt');
+  let raw;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+  const deps = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    if (trimmed.startsWith('-')) continue; // -r includes, -e editables, etc.
+    const name = pythonRequirementName(trimmed);
+    if (name) deps.push(name);
+  }
+  if (deps.length === 0) return null;
+  return {
+    dependencies: [...new Set(deps)],
+    devDependencies: [],
+  };
+}
+
+// Extract the package name from a Python requirement spec like:
+//   "fastapi"  "fastapi>=0.100"  "fastapi[standard]==0.115.0"  "django ; python_version < '3.10'"
+function pythonRequirementName(spec) {
+  const trimmed = spec.trim().replace(/^['"]|['"]$/g, '');
+  if (!trimmed) return null;
+  // Stop at first comparator, environment marker, extras bracket, or whitespace.
+  const m = trimmed.match(/^([A-Za-z0-9_][A-Za-z0-9_.\-]*)/);
+  if (!m) return null;
+  return m[1].toLowerCase();
+}
+
+// Tiny TOML reader: returns a map of section-name → key/value pairs
+// (with array-of-strings values returned as the raw string of the array,
+// since we only need to inspect a few of them).
+function parseTomlSections(raw) {
+  const sections = { '': {} };
+  let current = '';
+  const lines = raw.split(/\r?\n/);
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    const stripped = line.trim();
+    if (!stripped || stripped.startsWith('#')) {
+      i++;
+      continue;
+    }
+    const headerMatch = stripped.match(/^\[\s*([^\]]+?)\s*\]$/);
+    if (headerMatch) {
+      current = headerMatch[1].trim();
+      sections[current] = sections[current] ?? {};
+      i++;
+      continue;
+    }
+    const kvMatch = stripped.match(/^([A-Za-z0-9_\-]+)\s*=\s*(.*)$/);
+    if (!kvMatch) {
+      i++;
+      continue;
+    }
+    const key = kvMatch[1];
+    let value = kvMatch[2].trim();
+    // Handle multi-line arrays: [ ... \n ... \n ]
+    if (value.startsWith('[') && !value.includes(']')) {
+      let buf = value;
+      while (i + 1 < lines.length) {
+        i++;
+        buf += '\n' + lines[i];
+        if (lines[i].includes(']')) break;
+      }
+      value = buf;
+    }
+    // Unquote simple scalar string values (leave arrays/inline-tables alone).
+    if (
+      !value.startsWith('[') &&
+      !value.startsWith('{') &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    sections[current][key] = value;
+    i++;
+  }
+  return sections;
+}
+
+function parseTomlArrayString(section, key) {
+  if (!section) return [];
+  const raw = section[key];
+  if (!raw || typeof raw !== 'string') return [];
+  const m = raw.match(/^\[([\s\S]*)\]$/);
+  if (!m) return [];
+  const inner = m[1];
+  // Split on commas, strip quotes and inline comments
+  return inner
+    .split(',')
+    .map((s) => s.trim().replace(/#.*$/, '').trim())
+    .filter(Boolean)
+    .map((s) => s.replace(/^['"]|['"]$/g, ''));
 }
 
 function detectFrameworks(packageMeta) {
@@ -180,7 +405,7 @@ function detectOrms(packageMeta) {
   return [...new Set(found)];
 }
 
-async function detectRoutes(root, files) {
+async function detectRoutes(root, files, frameworks) {
   const routes = [];
 
   for (const file of files) {
@@ -189,6 +414,16 @@ async function detectRoutes(root, files) {
   }
 
   await detectFrameworkRoutes(root, files, routes);
+
+  if (frameworks.includes('FastAPI') || frameworks.includes('Starlette')) {
+    await detectFastapiRoutes(root, files, routes);
+  }
+  if (frameworks.includes('Flask')) {
+    await detectFlaskRoutes(root, files, routes);
+  }
+  if (frameworks.includes('Django')) {
+    await detectDjangoRoutes(root, files, routes);
+  }
 
   return routes;
 }
@@ -219,7 +454,8 @@ function nextRouteFromFile(file) {
 const TEST_FILE_RE = /(?:^|\/)(?:test|tests|__tests__|spec|specs)\/|\.(?:test|spec)\.[mc]?[jt]sx?$/;
 
 async function detectFrameworkRoutes(root, files, out) {
-  const RE = /\b(?:app|router|fastify|koa|server)\s*\.\s*(get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/gi;
+  // Negative lookbehind for @ avoids matching Python decorators like @app.get("/x").
+  const RE = /(?<!@)\b(?:app|router|fastify|koa|server)\s*\.\s*(get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/gi;
   const candidates = files.filter(
     (f) => /\.(?:[mc]?[jt]s)$/.test(f) && !TEST_FILE_RE.test(f),
   );
@@ -254,6 +490,12 @@ async function detectModels(root, files, orms) {
   }
   if (orms.includes('Drizzle')) {
     models.push(...(await parseDrizzle(root, files)));
+  }
+  if (orms.includes('SQLAlchemy')) {
+    models.push(...(await parseSqlalchemy(root, files)));
+  }
+  if (orms.includes('Django ORM')) {
+    models.push(...(await parseDjangoModels(root, files)));
   }
 
   return models;
@@ -324,6 +566,180 @@ async function parseDrizzle(root, files) {
     let m;
     while ((m = RE.exec(content)) !== null) {
       out.push({ name: m[1], file, fields: [], source: 'drizzle' });
+    }
+  }
+  return out;
+}
+
+// ----- Python route detection ---------------------------------------------
+
+function pythonCandidates(files) {
+  return files.filter((f) => PY_FILE_RE.test(f) && !PY_TEST_FILE_RE.test(f));
+}
+
+async function detectFastapiRoutes(root, files, out) {
+  // Matches @app.get("/path"), @router.post("/path"), @api.delete(...)
+  const RE = /@(?:\w+)\.(get|post|put|patch|delete|options|head)\s*\(\s*(?:path\s*=\s*)?['"]([^'"]+)['"]/gi;
+  for (const file of pythonCandidates(files)) {
+    let content;
+    try {
+      content = await readFile(join(root, file), 'utf8');
+    } catch {
+      continue;
+    }
+    if (content.length > 200_000) continue;
+    if (!/@\w+\.(get|post|put|patch|delete|options|head)\s*\(/i.test(content)) continue;
+    let m;
+    while ((m = RE.exec(content)) !== null) {
+      out.push({
+        method: m[1].toUpperCase(),
+        path: m[2],
+        file,
+        source: 'fastapi',
+      });
+    }
+  }
+}
+
+async function detectFlaskRoutes(root, files, out) {
+  const ROUTE_RE = /@(?:\w+)\.route\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*methods\s*=\s*\[([^\]]+)\])?/g;
+  const SHORT_RE = /@(?:\w+)\.(get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/gi;
+  for (const file of pythonCandidates(files)) {
+    let content;
+    try {
+      content = await readFile(join(root, file), 'utf8');
+    } catch {
+      continue;
+    }
+    if (content.length > 200_000) continue;
+    if (!/@\w+\.(route|get|post|put|patch|delete)\s*\(/i.test(content)) continue;
+
+    let m;
+    while ((m = ROUTE_RE.exec(content)) !== null) {
+      const methods = m[2]
+        ? m[2].split(',').map((s) => s.trim().replace(/['"]/g, '').toUpperCase()).filter(Boolean)
+        : ['GET'];
+      for (const method of methods) {
+        out.push({ method, path: m[1], file, source: 'flask' });
+      }
+    }
+    while ((m = SHORT_RE.exec(content)) !== null) {
+      out.push({
+        method: m[1].toUpperCase(),
+        path: m[2],
+        file,
+        source: 'flask',
+      });
+    }
+  }
+}
+
+async function detectDjangoRoutes(root, files, out) {
+  // Django defines routes in urls.py via path("foo/", view) or re_path(r"^foo$", view).
+  // We pull the literal URL string; the view-name is best-effort.
+  const PATH_RE = /\b(?:re_path|path)\s*\(\s*(?:r?['"])([^'"]+)['"]/g;
+  for (const file of pythonCandidates(files)) {
+    if (!/(?:^|\/)urls\.py$/.test(file)) continue;
+    let content;
+    try {
+      content = await readFile(join(root, file), 'utf8');
+    } catch {
+      continue;
+    }
+    if (content.length > 200_000) continue;
+    let m;
+    while ((m = PATH_RE.exec(content)) !== null) {
+      out.push({
+        method: 'ANY',
+        path: m[1].startsWith('/') ? m[1] : '/' + m[1],
+        file,
+        source: 'django',
+      });
+    }
+  }
+}
+
+// ----- Python model detection ---------------------------------------------
+
+async function parseSqlalchemy(root, files) {
+  const out = [];
+  // class Foo(Base): ... or class Foo(db.Model): ...
+  const CLASS_RE = /^class\s+(\w+)\s*\(([^)]*)\)\s*:/gm;
+  const COLUMN_RE = /^\s{4,}(\w+)\s*(?::\s*[^=]+)?=\s*(?:mapped_column|Column)\s*\(/gm;
+  const TABLE_RE = /__tablename__\s*=\s*['"]([^'"]+)['"]/;
+  for (const file of pythonCandidates(files)) {
+    let content;
+    try {
+      content = await readFile(join(root, file), 'utf8');
+    } catch {
+      continue;
+    }
+    if (content.length > 200_000) continue;
+    if (!/sqlalchemy|declarative_base|DeclarativeBase|Mapped|db\.Model/.test(content)) continue;
+    let m;
+    while ((m = CLASS_RE.exec(content)) !== null) {
+      const baseList = m[2];
+      const isModel = /\bBase\b|\bDeclarativeBase\b|db\.Model|\bModel\b/.test(baseList);
+      if (!isModel) continue;
+      // find the class body (rough — until next top-level "class " or end of file)
+      const start = m.index + m[0].length;
+      const remainder = content.slice(start);
+      const next = remainder.search(/^class\s+\w+\s*\(/m);
+      const body = next >= 0 ? remainder.slice(0, next) : remainder;
+      const fields = [];
+      let f;
+      const localCol = new RegExp(COLUMN_RE.source, 'gm');
+      while ((f = localCol.exec(body)) !== null) {
+        if (!fields.includes(f[1])) fields.push(f[1]);
+        if (fields.length >= 10) break;
+      }
+      const tableMatch = body.match(TABLE_RE);
+      out.push({
+        name: m[1],
+        file,
+        fields,
+        tableName: tableMatch ? tableMatch[1] : undefined,
+        source: 'sqlalchemy',
+      });
+    }
+  }
+  return out;
+}
+
+async function parseDjangoModels(root, files) {
+  const out = [];
+  const CLASS_RE = /^class\s+(\w+)\s*\(([^)]*)\)\s*:/gm;
+  const FIELD_RE = /^\s{4,}(\w+)\s*=\s*models\.\w+/gm;
+  for (const file of pythonCandidates(files)) {
+    if (!/(?:^|\/)models(?:\.py|\/)/.test(file)) continue;
+    let content;
+    try {
+      content = await readFile(join(root, file), 'utf8');
+    } catch {
+      continue;
+    }
+    if (content.length > 200_000) continue;
+    if (!/models\.Model/.test(content)) continue;
+    let m;
+    while ((m = CLASS_RE.exec(content)) !== null) {
+      if (!/models\.Model/.test(m[2])) continue;
+      const start = m.index + m[0].length;
+      const remainder = content.slice(start);
+      const next = remainder.search(/^class\s+\w+\s*\(/m);
+      const body = next >= 0 ? remainder.slice(0, next) : remainder;
+      const fields = [];
+      let f;
+      const localField = new RegExp(FIELD_RE.source, 'gm');
+      while ((f = localField.exec(body)) !== null) {
+        if (!fields.includes(f[1])) fields.push(f[1]);
+        if (fields.length >= 10) break;
+      }
+      out.push({
+        name: m[1],
+        file,
+        fields,
+        source: 'django',
+      });
     }
   }
   return out;

--- a/src/utils/scan-warnings.js
+++ b/src/utils/scan-warnings.js
@@ -7,7 +7,7 @@ export function describeScanWarnings(scan, { includeFrameworkHint = false } = {}
   }
   if (includeFrameworkHint && (scan?.frameworks?.length ?? 0) === 0) {
     warnings.push(
-      "Heads up: no framework detected. Draftwise's scanner supports JS/TS (Next.js, Express, Fastify, Vue, Svelte) and common ORMs (Prisma, Mongoose, Drizzle). Other languages will produce shallow scans until language-specific support lands.",
+      "Heads up: no framework detected. Draftwise's scanner supports JS/TS (Next.js, Express, Fastify, Vue, Svelte), Python (FastAPI, Flask, Django), and common ORMs (Prisma, Mongoose, Drizzle, SQLAlchemy, Django ORM). Other languages will produce shallow scans until language-specific support lands.",
     );
   }
   return warnings;

--- a/test/core/scanner.test.js
+++ b/test/core/scanner.test.js
@@ -138,6 +138,226 @@ model Post {
     expect(result.files).toHaveLength(2);
   });
 
+  describe('Python support', () => {
+    it('detects FastAPI from requirements.txt and parses route decorators', async () => {
+      await writeFixture(dir, {
+        'requirements.txt': 'fastapi>=0.100\nuvicorn[standard]\n# comment\npydantic\n',
+        'app/main.py': `
+from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/healthz")
+def health():
+    return {"ok": True}
+
+@app.post("/users", response_model=User)
+async def create_user(user: User):
+    pass
+
+@router.delete("/users/{id}")
+def delete_user(id: int):
+    pass
+`,
+      });
+
+      const result = await scan(dir);
+      expect(result.frameworks).toContain('FastAPI');
+      expect(result.packageMeta.dependencies).toContain('fastapi');
+      expect(result.packageMeta.dependencies).toContain('uvicorn');
+      const routes = result.routes.map((r) => `${r.method} ${r.path}`).sort();
+      expect(routes).toContain('GET /healthz');
+      expect(routes).toContain('POST /users');
+      expect(routes).toContain('DELETE /users/{id}');
+    });
+
+    it('detects Flask routes including methods on @app.route', async () => {
+      await writeFixture(dir, {
+        'requirements.txt': 'flask\n',
+        'src/app.py': `
+from flask import Flask
+app = Flask(__name__)
+
+@app.route("/")
+def index():
+    return "ok"
+
+@app.route("/items", methods=["GET", "POST"])
+def items():
+    pass
+
+@app.get("/health")
+def health():
+    return "ok"
+`,
+      });
+
+      const result = await scan(dir);
+      expect(result.frameworks).toContain('Flask');
+      const lines = result.routes.map((r) => `${r.method} ${r.path}`).sort();
+      expect(lines).toContain('GET /');
+      expect(lines).toContain('GET /items');
+      expect(lines).toContain('POST /items');
+      expect(lines).toContain('GET /health');
+    });
+
+    it('detects Django routes from urls.py and Django ORM from settings', async () => {
+      await writeFixture(dir, {
+        'requirements.txt': 'django==4.2\npsycopg2-binary\n',
+        'project/urls.py': `
+from django.urls import path, re_path
+from . import views
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("api/users/", views.UserList.as_view()),
+    re_path(r"^api/users/(?P<pk>\\d+)$", views.UserDetail.as_view()),
+]
+`,
+      });
+
+      const result = await scan(dir);
+      expect(result.frameworks).toContain('Django');
+      expect(result.orms).toContain('Django ORM');
+      const paths = result.routes.map((r) => r.path).sort();
+      expect(paths).toContain('/admin/');
+      expect(paths).toContain('/api/users/');
+      expect(paths.some((p) => p.includes('api/users'))).toBe(true);
+    });
+
+    it('parses pyproject.toml PEP 621 dependencies', async () => {
+      await writeFixture(dir, {
+        'pyproject.toml': `
+[project]
+name = "demo"
+version = "0.1.0"
+description = "A demo project"
+dependencies = [
+  "fastapi>=0.100",
+  "sqlalchemy>=2.0",
+  "uvicorn",
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "ruff"]
+`,
+        'app/main.py': '# noop',
+      });
+
+      const result = await scan(dir);
+      expect(result.packageMeta.name).toBe('demo');
+      expect(result.packageMeta.dependencies).toEqual(
+        expect.arrayContaining(['fastapi', 'sqlalchemy', 'uvicorn']),
+      );
+      expect(result.packageMeta.devDependencies).toEqual(
+        expect.arrayContaining(['pytest', 'ruff']),
+      );
+      expect(result.frameworks).toContain('FastAPI');
+      expect(result.orms).toContain('SQLAlchemy');
+    });
+
+    it('parses pyproject.toml Poetry dependency tables', async () => {
+      await writeFixture(dir, {
+        'pyproject.toml': `
+[tool.poetry]
+name = "demo"
+version = "0.1.0"
+
+[tool.poetry.dependencies]
+python = "^3.11"
+flask = "^3.0"
+sqlalchemy = "^2.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.0"
+`,
+        'src/app.py': '# noop',
+      });
+
+      const result = await scan(dir);
+      expect(result.packageMeta.dependencies).toEqual(
+        expect.arrayContaining(['flask', 'sqlalchemy']),
+      );
+      expect(result.packageMeta.dependencies).not.toContain('python');
+      expect(result.packageMeta.devDependencies).toContain('pytest');
+      expect(result.frameworks).toContain('Flask');
+    });
+
+    it('parses SQLAlchemy models with class fields', async () => {
+      await writeFixture(dir, {
+        'requirements.txt': 'sqlalchemy>=2.0\n',
+        'app/models.py': `
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+class Base(DeclarativeBase):
+    pass
+
+class User(Base):
+    __tablename__ = "users"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(unique=True)
+
+class Post(Base):
+    __tablename__ = "posts"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    title: Mapped[str] = mapped_column()
+`,
+      });
+
+      const result = await scan(dir);
+      const names = result.models.map((m) => m.name).sort();
+      expect(names).toContain('User');
+      expect(names).toContain('Post');
+      const user = result.models.find((m) => m.name === 'User');
+      expect(user.fields).toContain('id');
+      expect(user.fields).toContain('email');
+      expect(user.tableName).toBe('users');
+    });
+
+    it('parses Django ORM models from models.py', async () => {
+      await writeFixture(dir, {
+        'requirements.txt': 'django==4.2\n',
+        'blog/models.py': `
+from django.db import models
+
+class Post(models.Model):
+    title = models.CharField(max_length=200)
+    body = models.TextField()
+    author = models.ForeignKey("auth.User", on_delete=models.CASCADE)
+
+class Comment(models.Model):
+    post = models.ForeignKey(Post, on_delete=models.CASCADE)
+    body = models.TextField()
+`,
+      });
+
+      const result = await scan(dir);
+      expect(result.orms).toContain('Django ORM');
+      const names = result.models.map((m) => m.name).sort();
+      expect(names).toEqual(['Comment', 'Post']);
+      const post = result.models.find((m) => m.name === 'Post');
+      expect(post.fields).toContain('title');
+      expect(post.fields).toContain('body');
+    });
+
+    it('skips Python test files when detecting routes', async () => {
+      await writeFixture(dir, {
+        'requirements.txt': 'fastapi\n',
+        'app/main.py': `@app.get("/real")
+def real(): pass`,
+        'tests/test_routes.py': `@app.get("/from-test")
+def from_test(): pass`,
+        'app/test_helpers.py': `@app.get("/helper-test")
+def helper(): pass`,
+      });
+
+      const result = await scan(dir);
+      const paths = result.routes.map((r) => r.path);
+      expect(paths).toContain('/real');
+      expect(paths).not.toContain('/from-test');
+      expect(paths).not.toContain('/helper-test');
+    });
+  });
+
   it('ignores node_modules and .git', async () => {
     await writeFixture(dir, {
       'package.json': '{}',


### PR DESCRIPTION
…ango ORM

Closes Q7 from CLAUDE.md's open questions and starts the multi-language expansion. Adds full Python support to the scanner alongside existing JS/TS detection.

Project metadata:
- readProjectMeta() unifies package.json + Python sources into a single packageMeta with a languages array. JS-only repos behave exactly as before.
- tryReadPyproject() handles both PEP 621 ([project] with dependencies = [...] and [project.optional-dependencies] dev = [...]) and Poetry ([tool.poetry.dependencies] and the new [tool.poetry.group.dev.dependencies] table). Python = "..." is filtered out of dependencies.
- tryReadRequirementsTxt() parses requirement specs, ignoring comments and -r/-e flags, extracting just the package names (handles extras like fastapi[standard] and version markers).
- A small TOML reader strips quotes from scalar string values and preserves array/inline-table syntax for downstream parsing.

Frameworks detected: FastAPI, Starlette, Flask, Django, Tornado (in addition to all the existing JS/TS frameworks). ORMs detected: SQLAlchemy (incl. alembic / sqlalchemy-utils), Django ORM (via the django package itself, since the ORM ships with Django), Peewee, Tortoise ORM.

Routes:
- detectFastapiRoutes() — @app.get("/x") and @router.post(...) on any decorator name, all HTTP verbs.
- detectFlaskRoutes() — @app.route("/x") with optional methods= list, plus @app.get/post/etc shortcuts.
- detectDjangoRoutes() — only scans urls.py files, parses path() and re_path() literals.
- All Python route detection skips test files (tests/, __tests__/, test_*.py, _test.py, conftest.py).

Models:
- parseSqlalchemy() detects classes inheriting from Base / DeclarativeBase / db.Model / Model, captures column names from Column() and mapped_column() bindings, and pulls __tablename__.
- parseDjangoModels() scans models.py files for classes inheriting from models.Model and pulls models.* field names.

Bug fixes caught while testing on the draftwise repo itself:
- Added a (?<!@) negative lookbehind to detectFrameworkRoutes so the JS regex doesn't match Python decorator syntax in comments (the docstring "@app.get(\"/path\")" inside scanner.js was getting picked up as a real Express route).
- Updated the no-framework-detected warning to list Python frameworks now that they're supported.

Ignore list extended with Python's standard noise: __pycache__, venv, .venv, env, .tox, .pytest_cache, .mypy_cache, .ruff_cache, site-packages, eggs, .eggs.

8 new tests covering FastAPI / Flask / Django routes, PEP 621 + Poetry pyproject.toml parsing, requirements.txt parsing, SQLAlchemy + Django models, and the Python test-file exclusion. 120 tests total, all passing.

Per docs-sync: CLAUDE.md scanner section now lists currently- supported frameworks/ORMs by language and notes Go/Rust as the next planned expansions; open questions Q7 marked resolved.