### PR TITLE
Cache scan results and filter explain by flow keywords

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ src/core/scanner.js       → codebase scanning (frameworks, routes, components,
 src/ai/provider.js        → routes complete() calls to the right provider adapter
 src/ai/providers/         → claude.js wired; openai.js + gemini.js stubbed
 src/ai/prompts/           → one prompt module per command. Each exports brownfield + greenfield SYSTEM constants, a selectSystem(projectState) helper, a buildPrompt() that branches on projectState, and an agent-mode instruction
-src/utils/                → config.js (yaml loader, returns projectState + stack), specs.js (list .draftwise/specs/), slug.js, overview.js (read .draftwise/overview.md for greenfield context)
+src/utils/                → config.js (yaml loader; returns projectState/stack/scanMaxFiles), specs.js (list .draftwise/specs/), slug.js, overview.js (read .draftwise/overview.md for greenfield context), scan-cache.js (fingerprinted scan cache, drop-in for scan()), flow-filter.js (narrow scan to flow-relevant items), scan-warnings.js (truncation + missing-framework messages)
 test/                     → vitest, mirrors src structure
 ```
 
@@ -132,6 +132,9 @@ Each command is a separate file under `src/commands/` with a single `export defa
 
 ```
 .draftwise/
+├── .gitignore                   # written by init; excludes .cache/ from version control
+├── .cache/
+│   └── scan.json                # fingerprinted scan cache (gitignored)
 ├── overview.md                  # codebase summary (brownfield) or greenfield plan
 ├── scaffold.json                # greenfield only: structured stack data for `draftwise scaffold`
 ├── flows/                       # `draftwise explain` snapshots (brownfield)
@@ -270,9 +273,9 @@ When a contributor proposes one of these, gently redirect — they're worth doin
 ## Open questions (post-v1)
 
 1. ~~**Scan depth.**~~ ✅ Resolved. Scanner now caps at `DEFAULT_MAX_FILES` (5000) by default; users can raise via `scan.max_files` in `config.yaml`. When the cap is hit, scan results carry `truncated: true` and commands surface a warning pointing at the config knob.
-2. **Scan caching.** Today every command re-runs the scanner — no caching, no incremental updates. Cheap enough for typical repos but a bottleneck on huge ones. Worth tackling alongside flow-aware filtering for `explain`.
+2. ~~**Scan caching.**~~ ✅ Resolved. `src/utils/scan-cache.js` introduces `cachedScan(root, opts)` — a wrapper around the raw scanner that fingerprints the tree (file path + mtime, hashed with `maxFiles` mixed in), stores results at `.draftwise/.cache/scan.json`, and returns the cached scan when fingerprints match. Cache invalidates automatically on any file change or `scan.max_files` bump. Init writes a `.draftwise/.gitignore` excluding `.cache/`.
 3. **Default model.** `claude-sonnet-4-6` hardcoded in `src/ai/providers/claude.js` as the default; users can override via `ai.model` in `config.yaml`. Reasonable for now.
-4. **Large flow tracing.** `explain` sends the full scanner output to the model regardless of flow size. May need flow-aware filtering (only include relevant files) for very large flows.
+4. ~~**Large flow tracing.**~~ ✅ Resolved. `src/utils/flow-filter.js` provides `filterScanForFlow(scan, flow)` — tokenizes the flow name (lowercase, drops punctuation, strips 1-char tokens), filters routes/components/models to items whose paths/names contain any token. Falls back to the unfiltered category if filtering wipes a previously-non-empty list (better to over-include than send empty arrays). `explain` runs every scan through this filter before building the prompt.
 5. ~~**Unsupported frameworks.**~~ ✅ Resolved. `init` and `scan` now log an explicit "no framework detected" hint when the scanner returns an empty `frameworks` array, listing what's supported.
 6. **OpenAI / Gemini adapters.** Stubbed with a clear error in `src/ai/provider.js`. Wire up when a user asks for them.
 7. ~~**Scanner language coverage — Python.**~~ ✅ Resolved. Python support added in PR after `0.0.1`: detects FastAPI / Starlette / Flask / Django / Tornado from `requirements.txt` or `pyproject.toml` (PEP 621 + Poetry), parses FastAPI / Flask decorator-based routes, parses Django `urls.py` `path(...)` / `re_path(...)`, and parses SQLAlchemy + Django ORM models. Test files (`tests/`, `test_*.py`, `_test.py`, `conftest.py`) are excluded from route detection. Go and Rust are the next planned language expansions.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ draftwise new "your feature idea" # draft a new spec
 
 ```
 .draftwise/
+├── .gitignore                      # written by init; keeps the cache out of version control
 ├── overview.md                     # codebase summary (brownfield) or greenfield plan
 ├── scaffold.json                   # greenfield only: structured stack data for `draftwise scaffold`
 ├── specs/
@@ -140,7 +141,7 @@ draftwise new "your feature idea" # draft a new spec
 └── config.yaml
 ```
 
-Markdown. Version-controlled. Travels with your repo.
+Markdown. Version-controlled. Travels with your repo. (Draftwise also writes a `.cache/` folder that's gitignored automatically — fingerprint-based scan cache that invalidates on any code change.)
 
 ---
 

--- a/src/commands/explain.js
+++ b/src/commands/explain.js
@@ -1,9 +1,10 @@
 import { writeFile, mkdir, access } from 'node:fs/promises';
 import { join } from 'node:path';
-import { scan as defaultScan } from '../core/scanner.js';
+import { cachedScan as defaultScan } from '../utils/scan-cache.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { describeScanWarnings } from '../utils/scan-warnings.js';
+import { filterScanForFlow } from '../utils/flow-filter.js';
 import { SYSTEM, buildPrompt, buildAgentInstruction } from '../ai/prompts/explain.js';
 import { slugify } from '../utils/slug.js';
 
@@ -71,7 +72,8 @@ export default async function explainCommand(args = [], deps = {}) {
     );
   }
 
-  const scanForPrompt = compactScan(result);
+  const compact = compactScan(result);
+  const scanForPrompt = filterScanForFlow(compact, flow);
 
   if (config.mode === 'agent') {
     log('');

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -2,7 +2,7 @@ import { mkdir, access, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { stringify as yamlStringify } from 'yaml';
 import { select, input } from '@inquirer/prompts';
-import { scan as defaultScan } from '../core/scanner.js';
+import { cachedScan as defaultScan } from '../utils/scan-cache.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { describeScanWarnings } from '../utils/scan-warnings.js';
 import {
@@ -21,6 +21,10 @@ const ENV_VAR_BY_PROVIDER = {
   openai: 'OPENAI_API_KEY',
   gemini: 'GEMINI_API_KEY',
 };
+
+const DRAFTWISE_GITIGNORE = `# Draftwise generates these locally; don't commit them.
+.cache/
+`;
 
 const BROWNFIELD_OVERVIEW_PLACEHOLDER = `# Codebase overview
 
@@ -197,11 +201,13 @@ async function runBrownfield({ cwd, log, scan, draftwiseDir, aiConfig }) {
     buildConfigYaml({ ...aiConfig, projectState: 'brownfield' }),
     'utf8',
   );
+  await writeFile(join(draftwiseDir, '.gitignore'), DRAFTWISE_GITIGNORE, 'utf8');
 
   log('Created .draftwise/ with:');
   log('  • overview.md   (placeholder — `draftwise scan` will fill it in)');
   log('  • specs/        (your specs will live here)');
   log('  • config.yaml   (AI mode + project state)');
+  log('  • .gitignore    (excludes .cache/ from version control)');
   log('');
   if (aiConfig.mode === 'api') {
     log(
@@ -249,11 +255,17 @@ async function runGreenfield({
       buildConfigYaml({ ...aiConfig, projectState: 'greenfield' }),
       'utf8',
     );
+    await writeFile(
+      join(draftwiseDir, '.gitignore'),
+      DRAFTWISE_GITIGNORE,
+      'utf8',
+    );
 
     log('Created .draftwise/ with:');
     log('  • overview.md   (placeholder — your agent will rewrite from the conversation)');
     log('  • specs/        (your specs will live here)');
     log('  • config.yaml   (AI mode + project state)');
+    log('  • .gitignore    (excludes .cache/ from version control)');
     log('');
     log('Run draftwise commands inside your coding agent (Claude Code, Cursor, etc.).');
     return;
@@ -330,6 +342,7 @@ async function runGreenfield({
     }),
     'utf8',
   );
+  await writeFile(join(draftwiseDir, '.gitignore'), DRAFTWISE_GITIGNORE, 'utf8');
 
   // Persist the structured stack data so `draftwise scaffold` can use it later.
   await writeFile(

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -1,7 +1,7 @@
 import { writeFile, mkdir, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { input, select } from '@inquirer/prompts';
-import { scan as defaultScan } from '../core/scanner.js';
+import { cachedScan as defaultScan } from '../utils/scan-cache.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { readOverview as defaultReadOverview } from '../utils/overview.js';

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -1,6 +1,6 @@
 import { writeFile, access } from 'node:fs/promises';
 import { join } from 'node:path';
-import { scan as defaultScan } from '../core/scanner.js';
+import { cachedScan as defaultScan } from '../utils/scan-cache.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { describeScanWarnings } from '../utils/scan-warnings.js';

--- a/src/commands/tasks.js
+++ b/src/commands/tasks.js
@@ -1,7 +1,7 @@
 import { readFile, writeFile, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { select } from '@inquirer/prompts';
-import { scan as defaultScan } from '../core/scanner.js';
+import { cachedScan as defaultScan } from '../utils/scan-cache.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { listSpecs as defaultListSpecs } from '../utils/specs.js';

--- a/src/commands/tech.js
+++ b/src/commands/tech.js
@@ -1,7 +1,7 @@
 import { readFile, writeFile, access } from 'node:fs/promises';
 import { join } from 'node:path';
 import { select } from '@inquirer/prompts';
-import { scan as defaultScan } from '../core/scanner.js';
+import { cachedScan as defaultScan } from '../utils/scan-cache.js';
 import { loadConfig as defaultLoadConfig } from '../utils/config.js';
 import { complete as defaultComplete } from '../ai/provider.js';
 import { listSpecs as defaultListSpecs } from '../utils/specs.js';

--- a/src/core/scanner.js
+++ b/src/core/scanner.js
@@ -1,7 +1,7 @@
 import { readdir, readFile, access } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
 
-const IGNORE_DIRS = new Set([
+export const IGNORE_DIRS = new Set([
   'node_modules',
   '.git',
   '.draftwise',
@@ -30,7 +30,7 @@ const IGNORE_DIRS = new Set([
   '.eggs',
 ]);
 
-const CODE_EXTENSIONS = new Set([
+export const CODE_EXTENSIONS = new Set([
   '.js', '.mjs', '.cjs', '.jsx',
   '.ts', '.tsx', '.mts', '.cts',
   '.vue', '.svelte',

--- a/src/utils/flow-filter.js
+++ b/src/utils/flow-filter.js
@@ -1,0 +1,58 @@
+// Narrow scanner output to items that look related to a named flow.
+// The filter is a heuristic — we tokenize the flow name and keep
+// routes / components / models whose paths or names contain any token.
+// If filtering wipes out everything in a category that originally had
+// items, we fall back to the original (unfiltered) data — better to
+// over-include than to leave the model staring at empty arrays.
+
+export function filterScanForFlow(scan, flow) {
+  if (!scan || !flow) return scan;
+  const tokens = tokenize(flow);
+  if (tokens.length === 0) return scan;
+
+  const includes = (text) => {
+    if (!text) return false;
+    const lower = String(text).toLowerCase();
+    return tokens.some((t) => lower.includes(t));
+  };
+
+  const filterArr = (arr, fields) => {
+    if (!Array.isArray(arr)) return arr;
+    return arr.filter((item) =>
+      fields.some((f) => includes(typeof item === 'string' ? item : item?.[f])),
+    );
+  };
+
+  const filteredRoutes = filterArr(scan.routes, ['path', 'file', 'name']);
+  const filteredComponents = filterArr(scan.components, ['name', 'file']);
+  const filteredModels = filterArr(scan.models, ['name', 'file']);
+
+  return {
+    ...scan,
+    routes: pickFiltered(scan.routes, filteredRoutes),
+    components: pickFiltered(scan.components, filteredComponents),
+    models: pickFiltered(scan.models, filteredModels),
+    flowFilter: {
+      flow,
+      tokens,
+      // Whether we actually filtered or fell back per-category
+      routes: filteredRoutes.length > 0 || (scan.routes ?? []).length === 0,
+      components:
+        filteredComponents.length > 0 || (scan.components ?? []).length === 0,
+      models: filteredModels.length > 0 || (scan.models ?? []).length === 0,
+    },
+  };
+}
+
+function tokenize(flow) {
+  return String(flow)
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t && t.length > 1);
+}
+
+function pickFiltered(original, filtered) {
+  if (!Array.isArray(original)) return filtered;
+  if (filtered.length === 0 && original.length > 0) return original;
+  return filtered;
+}

--- a/src/utils/scan-cache.js
+++ b/src/utils/scan-cache.js
@@ -1,0 +1,120 @@
+import { readdir, readFile, writeFile, mkdir, stat } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join, relative, sep } from 'node:path';
+import {
+  scan as defaultScan,
+  IGNORE_DIRS,
+  CODE_EXTENSIONS,
+  DEFAULT_MAX_FILES,
+} from '../core/scanner.js';
+
+const CACHE_REL_PATH = ['.draftwise', '.cache', 'scan.json'];
+
+function cachePath(root) {
+  return join(root, ...CACHE_REL_PATH);
+}
+
+export async function cachedScan(root, options = {}) {
+  const useCache = options.useCache !== false;
+  const scan = options.scan ?? defaultScan;
+  const maxFiles = options.maxFiles ?? DEFAULT_MAX_FILES;
+
+  if (!useCache) {
+    return scan(root, { maxFiles });
+  }
+
+  const fingerprint = await computeFingerprint(root, maxFiles);
+  const path = cachePath(root);
+  const cached = await readCache(path);
+
+  if (cached && cached.fingerprint === fingerprint) {
+    return { ...cached.result, fromCache: true };
+  }
+
+  const fresh = await scan(root, { maxFiles });
+  await writeCache(path, {
+    fingerprint,
+    savedAt: new Date().toISOString(),
+    result: fresh,
+  });
+  return { ...fresh, fromCache: false };
+}
+
+async function readCache(path) {
+  try {
+    const raw = await readFile(path, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed.fingerprint === 'string' &&
+      parsed.result &&
+      typeof parsed.result === 'object'
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Missing or unparseable — treat as no cache.
+  }
+  return null;
+}
+
+async function writeCache(path, payload) {
+  try {
+    await mkdir(join(path, '..'), { recursive: true });
+    await writeFile(path, JSON.stringify(payload), 'utf8');
+  } catch {
+    // Cache writes are best-effort; swallow errors so they don't fail the command.
+  }
+}
+
+async function computeFingerprint(root, maxFiles) {
+  const entries = [];
+  const state = { count: 0, max: maxFiles, truncated: false };
+  await walkForFingerprint(root, root, entries, state);
+  entries.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  const hash = createHash('sha256');
+  hash.update(`maxFiles:${maxFiles}\n`);
+  for (const e of entries) hash.update(`${e.path}\t${e.mtimeMs}\n`);
+  return hash.digest('hex');
+}
+
+async function walkForFingerprint(root, dir, out, state) {
+  if (state.truncated) return;
+  let dirents;
+  try {
+    dirents = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const ent of dirents) {
+    if (state.truncated) return;
+    if (IGNORE_DIRS.has(ent.name)) continue;
+    if (ent.name.startsWith('.')) continue;
+    const full = join(dir, ent.name);
+    if (ent.isDirectory()) {
+      await walkForFingerprint(root, full, out, state);
+    } else if (ent.isFile()) {
+      if (!CODE_EXTENSIONS.has(extOf(ent.name))) continue;
+      if (state.count >= state.max) {
+        state.truncated = true;
+        return;
+      }
+      let st;
+      try {
+        st = await stat(full);
+      } catch {
+        continue;
+      }
+      out.push({
+        path: relative(root, full).split(sep).join('/'),
+        mtimeMs: Math.floor(st.mtimeMs),
+      });
+      state.count++;
+    }
+  }
+}
+
+function extOf(name) {
+  const dot = name.lastIndexOf('.');
+  return dot < 0 ? '' : name.slice(dot).toLowerCase();
+}

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -116,6 +116,9 @@ describe('draftwise init', () => {
       expect(config).toContain('mode: agent');
       expect(config).toContain('state: brownfield');
       expect(config).not.toContain('provider:');
+
+      const gitignore = await readFile(join(drafts, '.gitignore'), 'utf8');
+      expect(gitignore).toContain('.cache/');
     });
 
     it('writes provider and api_key_env in api mode', async () => {

--- a/test/utils/flow-filter.test.js
+++ b/test/utils/flow-filter.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { filterScanForFlow } from '../../src/utils/flow-filter.js';
+
+const SAMPLE = {
+  files: ['src/checkout/index.ts', 'src/auth/login.ts'],
+  routes: [
+    { method: 'POST', path: '/checkout', file: 'src/checkout/index.ts' },
+    { method: 'POST', path: '/login', file: 'src/auth/login.ts' },
+  ],
+  components: [
+    { name: 'CheckoutForm', file: 'src/checkout/Form.tsx' },
+    { name: 'LoginPage', file: 'src/auth/Login.tsx' },
+  ],
+  models: [
+    { name: 'Cart', file: 'prisma/schema.prisma', fields: ['id'] },
+    { name: 'User', file: 'prisma/schema.prisma', fields: ['id'] },
+  ],
+};
+
+describe('filterScanForFlow', () => {
+  it('keeps only items matching the flow tokens', () => {
+    const out = filterScanForFlow(SAMPLE, 'checkout');
+    expect(out.routes.map((r) => r.path)).toEqual(['/checkout']);
+    expect(out.components.map((c) => c.name)).toEqual(['CheckoutForm']);
+    // No model with "checkout" matches; falls back to original (Cart, User).
+    expect(out.models).toHaveLength(2);
+    expect(out.flowFilter.tokens).toEqual(['checkout']);
+  });
+
+  it('matches by file path too', () => {
+    const out = filterScanForFlow(SAMPLE, 'auth');
+    expect(out.routes.map((r) => r.path)).toEqual(['/login']);
+    expect(out.components.map((c) => c.name)).toEqual(['LoginPage']);
+  });
+
+  it('handles multi-word flows and case-insensitive matching', () => {
+    const out = filterScanForFlow(SAMPLE, 'User Login');
+    const routes = out.routes.map((r) => r.path);
+    expect(routes).toContain('/login');
+    expect(out.components.some((c) => c.name === 'LoginPage')).toBe(true);
+  });
+
+  it('falls back to the unfiltered category when filtering wipes it', () => {
+    const out = filterScanForFlow(SAMPLE, 'nonexistent-flow-name');
+    // No matches at all, so each non-empty category falls back to the original.
+    expect(out.routes).toHaveLength(2);
+    expect(out.components).toHaveLength(2);
+    expect(out.models).toHaveLength(2);
+  });
+
+  it('returns the scan unchanged when flow has no usable tokens', () => {
+    const out = filterScanForFlow(SAMPLE, '!!');
+    expect(out).toBe(SAMPLE);
+  });
+
+  it('returns the scan unchanged when flow is empty', () => {
+    expect(filterScanForFlow(SAMPLE, '')).toBe(SAMPLE);
+    expect(filterScanForFlow(SAMPLE, undefined)).toBe(SAMPLE);
+  });
+
+  it('passes through when scan is null', () => {
+    expect(filterScanForFlow(null, 'checkout')).toBe(null);
+  });
+});

--- a/test/utils/scan-cache.test.js
+++ b/test/utils/scan-cache.test.js
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  mkdtemp,
+  rm,
+  mkdir,
+  writeFile,
+  readFile,
+  utimes,
+  access,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { cachedScan } from '../../src/utils/scan-cache.js';
+
+async function pathExists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function seedRepo(dir) {
+  await writeFile(join(dir, 'package.json'), '{"name":"demo"}', 'utf8');
+  await mkdir(join(dir, 'src'), { recursive: true });
+  await writeFile(join(dir, 'src', 'a.js'), '// a', 'utf8');
+  await writeFile(join(dir, 'src', 'b.js'), '// b', 'utf8');
+}
+
+describe('cachedScan', () => {
+  let dir;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'draftwise-cache-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('runs the scan on first call and writes the cache file', async () => {
+    await seedRepo(dir);
+    const calls = [];
+    const fakeScan = async (root, opts) => {
+      calls.push({ root, opts });
+      return { files: ['src/a.js', 'src/b.js'], frameworks: [], routes: [], components: [], models: [], packageMeta: {} };
+    };
+
+    const result = await cachedScan(dir, { scan: fakeScan });
+    expect(calls).toHaveLength(1);
+    expect(result.fromCache).toBe(false);
+    expect(result.files).toEqual(['src/a.js', 'src/b.js']);
+    expect(await pathExists(join(dir, '.draftwise', '.cache', 'scan.json'))).toBe(
+      true,
+    );
+  });
+
+  it('returns the cache on second call when nothing changed', async () => {
+    await seedRepo(dir);
+    let calls = 0;
+    const fakeScan = async () => {
+      calls++;
+      return { files: ['src/a.js'], frameworks: [], routes: [], components: [], models: [], packageMeta: {} };
+    };
+
+    const first = await cachedScan(dir, { scan: fakeScan });
+    expect(first.fromCache).toBe(false);
+
+    const second = await cachedScan(dir, { scan: fakeScan });
+    expect(second.fromCache).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  it('invalidates the cache when a source file is touched', async () => {
+    await seedRepo(dir);
+    let calls = 0;
+    const fakeScan = async () => {
+      calls++;
+      return { files: ['src/a.js'], frameworks: [], routes: [], components: [], models: [], packageMeta: {} };
+    };
+
+    await cachedScan(dir, { scan: fakeScan });
+    expect(calls).toBe(1);
+
+    // Touch a file's mtime forward.
+    const future = new Date(Date.now() + 60_000);
+    await utimes(join(dir, 'src', 'a.js'), future, future);
+
+    await cachedScan(dir, { scan: fakeScan });
+    expect(calls).toBe(2);
+  });
+
+  it('invalidates when maxFiles changes (config knob bumped)', async () => {
+    await seedRepo(dir);
+    let calls = 0;
+    const fakeScan = async (root, opts) => {
+      calls++;
+      return { files: ['src/a.js'], frameworks: [], routes: [], components: [], models: [], packageMeta: {}, maxFiles: opts.maxFiles };
+    };
+
+    await cachedScan(dir, { scan: fakeScan, maxFiles: 100 });
+    await cachedScan(dir, { scan: fakeScan, maxFiles: 100 });
+    expect(calls).toBe(1);
+
+    await cachedScan(dir, { scan: fakeScan, maxFiles: 200 });
+    expect(calls).toBe(2);
+  });
+
+  it('useCache: false bypasses the cache entirely', async () => {
+    await seedRepo(dir);
+    let calls = 0;
+    const fakeScan = async () => {
+      calls++;
+      return { files: ['src/a.js'], frameworks: [], routes: [], components: [], models: [], packageMeta: {} };
+    };
+
+    await cachedScan(dir, { scan: fakeScan });
+    await cachedScan(dir, { scan: fakeScan, useCache: false });
+    await cachedScan(dir, { scan: fakeScan, useCache: false });
+    expect(calls).toBe(3);
+  });
+
+  it('survives a corrupt cache file by re-scanning', async () => {
+    await seedRepo(dir);
+    await mkdir(join(dir, '.draftwise', '.cache'), { recursive: true });
+    await writeFile(
+      join(dir, '.draftwise', '.cache', 'scan.json'),
+      '{not valid json',
+      'utf8',
+    );
+
+    let calls = 0;
+    const fakeScan = async () => {
+      calls++;
+      return { files: ['src/a.js'], frameworks: [], routes: [], components: [], models: [], packageMeta: {} };
+    };
+
+    const result = await cachedScan(dir, { scan: fakeScan });
+    expect(calls).toBe(1);
+    expect(result.fromCache).toBe(false);
+    // And the corrupt file got replaced with a valid one.
+    const fresh = await readFile(
+      join(dir, '.draftwise', '.cache', 'scan.json'),
+      'utf8',
+    );
+    expect(JSON.parse(fresh).fingerprint).toBeTypeOf('string');
+  });
+});


### PR DESCRIPTION
Closes Q2 (scan caching) and Q4 (large flow tracing) from CLAUDE.md.

Q2 — fingerprinted scan cache (src/utils/scan-cache.js):
- cachedScan(root, opts) wraps scan(): walks the tree once to collect (file path, mtime), hashes the sorted list along with the maxFiles option, compares to .draftwise/.cache/scan.json, and returns the cached result on match.
- Cache invalidates automatically on any file add/delete/edit (mtime change) and on scan.max_files config bumps.
- Survives a corrupt cache file by silently re-scanning.
- useCache: false bypasses the cache for ad-hoc fresh runs.
- Init now writes .draftwise/.gitignore with `.cache/` so the cache never gets accidentally committed.
- Every command that scans (init, scan, explain, new, tech, tasks) switched from `scan` to `cachedScan` via dep-injection swap — no signature change for tests.
- Scanner exports IGNORE_DIRS / CODE_EXTENSIONS so the cache's walk uses the same ignore rules as the real scan.

Q4 — flow-aware filtering (src/utils/flow-filter.js):
- filterScanForFlow(scan, flow) tokenizes the flow name (lower- case, drop punctuation, strip 1-char tokens), then narrows routes / components / models to items whose path / file / name contains any token. The full file list and packageMeta stay intact so the model still has the broader picture.
- Per-category fallback: if filtering wipes a previously non- empty category, that category falls back to the original unfiltered list — better to over-include than send the model empty arrays.
- explain runs every scan through this filter before building the prompt. For repos with many routes, the model now sees only flow-relevant routes/components/models, freeing up prompt budget for richer detail.

13 new tests across cache invalidation paths, corrupt-cache recovery, and flow-filter heuristics. 133 tests total.

Per docs-sync: CLAUDE.md open questions Q2 and Q4 marked resolved with implementation pointers; src/utils/ description expanded; .draftwise/ tree shows .gitignore + .cache/. README's repo tree now mentions the auto-managed gitignore and the cache folder.