### PR TITLE
Pin line endings to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,44 @@
+# Normalize line endings to LF in the repo and the working tree.
+# Avoids the "LF will be replaced by CRLF" Git warnings on Windows
+# and keeps the shebang in bin/draftwise.js portable across OSes.
+
+* text=auto eol=lf
+
+# Source
+*.js text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.jsx text eol=lf
+*.vue text eol=lf
+*.svelte text eol=lf
+*.py text eol=lf
+*.go text eol=lf
+*.rs text eol=lf
+*.rb text eol=lf
+
+# Config / data
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.md text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+
+# Shell / scripts
+*.sh text eol=lf
+bin/* text eol=lf
+
+# Binaries — leave alone (Git wouldn't convert anyway, but be explicit).
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Each released version is tagged in git (`v0.0.1`, `v0.1.0`, etc.) and includes t
 ## [Unreleased]
 
 ### Added
-- **Maintain CHANGELOG.md.** This file. Every functional PR going forward updates `[Unreleased]`; versioned sections move in when a release is tagged. — Ankur (#TBD)
+- **`.gitattributes` for cross-platform line-ending consistency.** Forces LF on commit and on checkout for source / config / docs / shell files; pins binary types as binary. Silences the "LF will be replaced by CRLF" warnings that Git on Windows surfaces on every commit, and keeps `bin/draftwise.js`'s shebang portable across OSes. — Ankur (#TBD)
+- **Maintain CHANGELOG.md.** This file. Every functional PR going forward updates `[Unreleased]`; versioned sections move in when a release is tagged. — Ankur (#19)
 
 ### Changed
 - **Prune resolved questions out of CLAUDE.md's Open questions section.** Real open items kept; resolved ones move into a new "Past decisions" section with implementation pointers. — Ankur (#18)


### PR DESCRIPTION
Silences the "LF will be replaced by CRLF" warnings that Git on Windows shows on nearly every commit. With this in place, the repo stores LF and the working tree gets LF on checkout, so there's no implicit conversion on either side.

Covers: JS / TS (incl. mjs / cjs / jsx / tsx / vue / svelte), Python, Go, Rust, Ruby, JSON / YAML / TOML / Markdown, HTML / CSS / SCSS, shell scripts, and bin/* (so the shebang in bin/draftwise.js stays portable across OSes). Common binary types are pinned as binary explicitly — Git wouldn't convert them anyway, but better to be loud.

Tests still pass at 133/133. Per the new CHANGELOG rule, [Unreleased] now records this change.