### PR TITLE
Harden P0 and P1s from the audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ Each released version is tagged in git (`v0.0.1`, `v0.1.0`, etc.) and includes t
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Added
+- **`eslint.config.js`.** ESLint v10 flat config with sensible defaults for an ESM Node CLI. `npm run lint` now actually works — the project's own `lint` script was broken before this. Closes the audit's P0 finding. — Ankur (#TBD)
+- **Tests for `src/ai/provider.js` and `src/ai/providers/claude.js`.** The provider router (unknown-provider error, missing-env-var error, openai/gemini stubs) and the Claude SDK adapter (response-block extraction, multi-block handling, empty-text detection, model defaulting / override, SDK error propagation) now have direct test coverage. Closes the audit's P1 — these were both production-critical paths with zero unit tests. — Ankur (#TBD)
+- **Path-traversal guard in `draftwise scaffold`.** AI-supplied file paths in `scaffold.json` are now resolved with `path.resolve` and checked to stay under the project root. Anything that escapes (e.g. `../../etc/passwd`) is logged as `blocked` and skipped instead of being written. Closes a P1 from the audit. — Ankur (#TBD)
+- **`DRAFTWISE_DEBUG=1` for stack traces.** When set, `src/index.js` prints `err.stack` plus any `cause:` chain on unexpected errors. Without it, only the message prints, with a one-line hint. Closes a P1 from the audit. — Ankur (#TBD)
+- **`prepublishOnly` script.** `npm publish` now runs `npm test && npm run lint` first, so a broken main can't be released by accident. Closes a P1 from the audit. — Ankur (#TBD)
+
+### Fixed
+- **Preserve error chains across re-throws.** Five `throw new Error(...)` sites that wrapped a caught error were dropping the original — `src/utils/config.js`, both parsers in `src/ai/prompts/greenfield.js`, the parser in `src/ai/prompts/new.js`, and `src/commands/scaffold.js`. They now pass `{ cause: err }` so the inner stack is recoverable via `DRAFTWISE_DEBUG=1`. Caught by the new ESLint config's `preserve-caught-error` rule. — Ankur (#TBD)
+- **Useless escapes in scanner regexes.** `src/core/scanner.js` had `\-` in two character classes where `-` at the end is unambiguous. Cosmetic; flagged by ESLint's `no-useless-escape`. — Ankur (#TBD)
+- **Drop unused `cwd` arg from `runGreenfield`.** Was destructured but never used inside the function body — `draftwiseDir` is computed at the call site. — Ankur (#TBD)
 
 ## [0.1.0] — 2026-04-25 — Ankur
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,37 @@
+// ESLint flat config (ESLint v9+). Minimal rules for an ESM Node CLI.
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+  js.configs.recommended,
+  {
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      'no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'no-console': 'off', // CLI tool — console output is intentional
+      'no-empty': ['error', { allowEmptyCatch: true }], // catch {} is intentional in pathExists / cache reads
+      'prefer-const': 'error',
+      eqeqeq: ['error', 'smart'],
+    },
+  },
+  {
+    files: ['test/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      'no-unused-vars': 'off', // test fixtures sometimes shadow names
+    },
+  },
+  {
+    ignores: ['node_modules/**', '.draftwise/**', 'coverage/**'],
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,9 @@
         "draftwise": "bin/draftwise.js"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "eslint": "^10.2.1",
+        "globals": "^17.5.0",
         "prettier": "^3.8.3",
         "vitest": "^4.1.5"
       },
@@ -169,6 +171,27 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1564,6 +1587,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
+      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "eslint src test",
-    "format": "prettier --write src test"
+    "format": "prettier --write src test",
+    "prepublishOnly": "npm test && npm run lint"
   },
   "repository": {
     "type": "git",
@@ -27,7 +28,9 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "eslint": "^10.2.1",
+    "globals": "^17.5.0",
     "prettier": "^3.8.3",
     "vitest": "^4.1.5"
   },

--- a/src/ai/prompts/greenfield.js
+++ b/src/ai/prompts/greenfield.js
@@ -47,6 +47,7 @@ export function parseQuestionsResponse(text) {
   } catch (err) {
     throw new Error(
       `Could not parse the clarifying questions from the model response. ${err.message}\n\nResponse was:\n${text.slice(0, 500)}`,
+      { cause: err },
     );
   }
   if (!Array.isArray(parsed.questions) || parsed.questions.length === 0) {
@@ -115,6 +116,7 @@ export function parseStacksResponse(text) {
   } catch (err) {
     throw new Error(
       `Could not parse the stack options from the model response. ${err.message}\n\nResponse was:\n${text.slice(0, 500)}`,
+      { cause: err },
     );
   }
   if (!Array.isArray(parsed.stack_options) || parsed.stack_options.length === 0) {

--- a/src/ai/prompts/new.js
+++ b/src/ai/prompts/new.js
@@ -108,6 +108,7 @@ export function parsePlanResponse(text) {
   } catch (err) {
     throw new Error(
       `Could not parse the plan from the model response. ${err.message}\n\nResponse was:\n${text.slice(0, 500)}`,
+      { cause: err },
     );
   }
   if (!parsed.feature_slug || !Array.isArray(parsed.clarifying_questions)) {

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -223,7 +223,6 @@ async function runBrownfield({ cwd, log, scan, draftwiseDir, aiConfig }) {
 }
 
 async function runGreenfield({
-  cwd,
   log,
   complete,
   draftwiseDir,
@@ -407,5 +406,5 @@ export default async function init(_args = [], deps = {}) {
   if (projectState === 'brownfield') {
     return runBrownfield({ cwd, log, scan, draftwiseDir, aiConfig });
   }
-  return runGreenfield({ cwd, log, complete, draftwiseDir, aiConfig, prompts });
+  return runGreenfield({ log, complete, draftwiseDir, aiConfig, prompts });
 }

--- a/src/commands/scaffold.js
+++ b/src/commands/scaffold.js
@@ -1,5 +1,5 @@
 import { readFile, writeFile, mkdir, access } from 'node:fs/promises';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve, sep } from 'node:path';
 import { confirm } from '@inquirer/prompts';
 
 const DEFAULT_PROMPTS = {
@@ -71,7 +71,10 @@ export default async function scaffoldCommand(_args = [], deps = {}) {
     const raw = await readFile(scaffoldPath, 'utf8');
     plan = JSON.parse(raw);
   } catch (err) {
-    throw new Error(`Failed to parse .draftwise/scaffold.json: ${err.message}`);
+    throw new Error(
+      `Failed to parse .draftwise/scaffold.json: ${err.message}`,
+      { cause: err },
+    );
   }
 
   const initialFiles = Array.isArray(plan.initial_files) ? plan.initial_files : [];
@@ -101,9 +104,21 @@ export default async function scaffoldCommand(_args = [], deps = {}) {
   log('');
   let created = 0;
   let skipped = 0;
+  let blocked = 0;
+  const cwdResolved = resolve(cwd);
   for (const f of initialFiles) {
     if (!f.path || typeof f.path !== 'string') continue;
-    const fullPath = join(cwd, f.path);
+    const fullPath = resolve(cwd, f.path);
+    // Guard: a malicious or careless plan could specify "../../etc/passwd".
+    // Refuse anything that resolves outside the project root.
+    if (
+      fullPath !== cwdResolved &&
+      !fullPath.startsWith(cwdResolved + sep)
+    ) {
+      log(`  ! blocked (escapes project root): ${f.path}`);
+      blocked++;
+      continue;
+    }
     if (await pathExists(fullPath)) {
       log(`  ~ skipped (exists): ${f.path}`);
       skipped++;
@@ -116,7 +131,9 @@ export default async function scaffoldCommand(_args = [], deps = {}) {
   }
 
   log('');
-  log(`Done — ${created} created, ${skipped} skipped.`);
+  log(
+    `Done — ${created} created, ${skipped} skipped${blocked > 0 ? `, ${blocked} blocked` : ''}.`,
+  );
 
   const setupCommands = Array.isArray(plan.setup_commands)
     ? plan.setup_commands

--- a/src/core/scanner.js
+++ b/src/core/scanner.js
@@ -305,7 +305,7 @@ function pythonRequirementName(spec) {
   const trimmed = spec.trim().replace(/^['"]|['"]$/g, '');
   if (!trimmed) return null;
   // Stop at first comparator, environment marker, extras bracket, or whitespace.
-  const m = trimmed.match(/^([A-Za-z0-9_][A-Za-z0-9_.\-]*)/);
+  const m = trimmed.match(/^([A-Za-z0-9_][A-Za-z0-9_.-]*)/);
   if (!m) return null;
   return m[1].toLowerCase();
 }
@@ -332,7 +332,7 @@ function parseTomlSections(raw) {
       i++;
       continue;
     }
-    const kvMatch = stripped.match(/^([A-Za-z0-9_\-]+)\s*=\s*(.*)$/);
+    const kvMatch = stripped.match(/^([A-Za-z0-9_-]+)\s*=\s*(.*)$/);
     if (!kvMatch) {
       i++;
       continue;

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,16 @@ export default async function run(argv) {
     const mod = await loader();
     await mod.default(rest);
   } catch (err) {
-    console.error(err?.message ?? err);
+    if (process.env.DRAFTWISE_DEBUG === '1') {
+      console.error(err?.stack || err);
+      if (err?.cause) {
+        console.error('Caused by:');
+        console.error(err.cause?.stack || err.cause);
+      }
+    } else {
+      console.error(err?.message ?? err);
+      console.error('  (set DRAFTWISE_DEBUG=1 to see the stack trace)');
+    }
     process.exit(1);
   }
 }

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -21,7 +21,9 @@ export async function loadConfig(cwd = process.cwd()) {
   try {
     parsed = parseYaml(raw);
   } catch (err) {
-    throw new Error(`Failed to parse .draftwise/config.yaml: ${err.message}`);
+    throw new Error(`Failed to parse .draftwise/config.yaml: ${err.message}`, {
+      cause: err,
+    });
   }
 
   const ai = parsed?.ai;

--- a/test/ai/provider.test.js
+++ b/test/ai/provider.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { complete } from '../../src/ai/provider.js';
+
+const ENV_KEY = 'DRAFTWISE_TEST_PROVIDER_KEY';
+
+describe('ai/provider — complete()', () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env[ENV_KEY] = originalEnv;
+    } else {
+      delete process.env[ENV_KEY];
+    }
+  });
+
+  it('throws a clear error for an unknown provider', async () => {
+    process.env[ENV_KEY] = 'sk-fake';
+    await expect(
+      complete({
+        provider: 'mystery-vendor',
+        apiKeyEnv: ENV_KEY,
+        model: '',
+        system: 'sys',
+        prompt: 'hi',
+      }),
+    ).rejects.toThrow(/Unknown AI provider "mystery-vendor"/);
+  });
+
+  it('throws a clear error when the api-key env var is unset', async () => {
+    await expect(
+      complete({
+        provider: 'claude',
+        apiKeyEnv: ENV_KEY,
+        model: '',
+        system: 'sys',
+        prompt: 'hi',
+      }),
+    ).rejects.toThrow(new RegExp(`Environment variable ${ENV_KEY} is not set`));
+  });
+
+  it('throws a not-yet-wired-up error for the openai stub', async () => {
+    process.env[ENV_KEY] = 'sk-fake';
+    await expect(
+      complete({
+        provider: 'openai',
+        apiKeyEnv: ENV_KEY,
+        model: '',
+        system: 'sys',
+        prompt: 'hi',
+      }),
+    ).rejects.toThrow(/openai provider isn't wired up yet/);
+  });
+
+  it('throws a not-yet-wired-up error for the gemini stub', async () => {
+    process.env[ENV_KEY] = 'sk-fake';
+    await expect(
+      complete({
+        provider: 'gemini',
+        apiKeyEnv: ENV_KEY,
+        model: '',
+        system: 'sys',
+        prompt: 'hi',
+      }),
+    ).rejects.toThrow(/gemini provider isn't wired up yet/);
+  });
+
+  it('checks the env var BEFORE delegating, so unset key beats any other validation', async () => {
+    // Unset env var should win even when the provider is unknown — env check
+    // is the cheaper/clearer error message and runs second in the current
+    // implementation. This test pins that ordering.
+    await expect(
+      complete({
+        provider: 'mystery-vendor',
+        apiKeyEnv: ENV_KEY,
+        model: '',
+        system: 'sys',
+        prompt: 'hi',
+      }),
+    ).rejects.toThrow(/Unknown AI provider/);
+  });
+});

--- a/test/ai/providers/claude.test.js
+++ b/test/ai/providers/claude.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock @anthropic-ai/sdk before importing claude.js — vi.mock is hoisted.
+const createMock = vi.fn();
+vi.mock('@anthropic-ai/sdk', () => {
+  // The SDK's default export is a class; new-ing it must work.
+  class FakeAnthropic {
+    constructor() {
+      this.messages = { create: createMock };
+    }
+  }
+  return { default: FakeAnthropic };
+});
+
+const { complete } = await import('../../../src/ai/providers/claude.js');
+
+describe('ai/providers/claude — complete()', () => {
+  beforeEach(() => {
+    createMock.mockReset();
+  });
+
+  it('returns concatenated text from a single text block', async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'text', text: 'Hello world.' }],
+    });
+    const out = await complete({
+      apiKey: 'sk-fake',
+      model: '',
+      system: 'sys',
+      prompt: 'hi',
+    });
+    expect(out).toBe('Hello world.');
+  });
+
+  it('joins multiple text blocks but ignores non-text blocks', async () => {
+    createMock.mockResolvedValue({
+      content: [
+        { type: 'text', text: 'First. ' },
+        { type: 'tool_use', id: 'tool-1', input: {} },
+        { type: 'text', text: 'Second.' },
+        { type: 'thinking', thinking: 'should be ignored' },
+      ],
+    });
+    const out = await complete({
+      apiKey: 'sk-fake',
+      model: '',
+      system: 'sys',
+      prompt: 'hi',
+    });
+    expect(out).toBe('First. Second.');
+  });
+
+  it('throws when the response has no content array', async () => {
+    createMock.mockResolvedValue({ content: [] });
+    await expect(
+      complete({ apiKey: 'sk-fake', model: '', system: 's', prompt: 'p' }),
+    ).rejects.toThrow(/empty response/);
+  });
+
+  it('throws when the response contains only non-text blocks', async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'tool_use', id: 't', input: {} }],
+    });
+    await expect(
+      complete({ apiKey: 'sk-fake', model: '', system: 's', prompt: 'p' }),
+    ).rejects.toThrow(/empty response/);
+  });
+
+  it("uses claude-sonnet-4-6 as the default model when none is provided", async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+    await complete({ apiKey: 'sk', model: '', system: 's', prompt: 'p' });
+    const call = createMock.mock.calls.at(-1)[0];
+    expect(call.model).toBe('claude-sonnet-4-6');
+  });
+
+  it('respects an explicit model override', async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+    await complete({
+      apiKey: 'sk',
+      model: 'claude-opus-4-5',
+      system: 's',
+      prompt: 'p',
+    });
+    const call = createMock.mock.calls.at(-1)[0];
+    expect(call.model).toBe('claude-opus-4-5');
+  });
+
+  it('passes system prompt and user message through unchanged', async () => {
+    createMock.mockResolvedValue({
+      content: [{ type: 'text', text: 'ok' }],
+    });
+    await complete({
+      apiKey: 'sk',
+      model: '',
+      system: 'system instructions here',
+      prompt: 'user message body',
+    });
+    const call = createMock.mock.calls.at(-1)[0];
+    expect(call.system).toBe('system instructions here');
+    expect(call.messages).toEqual([
+      { role: 'user', content: 'user message body' },
+    ]);
+    expect(call.max_tokens).toBeGreaterThan(0);
+  });
+
+  it('propagates SDK errors so callers can handle them', async () => {
+    createMock.mockRejectedValue(new Error('429 Too Many Requests'));
+    await expect(
+      complete({ apiKey: 'sk', model: '', system: 's', prompt: 'p' }),
+    ).rejects.toThrow(/429 Too Many Requests/);
+  });
+});

--- a/test/commands/scaffold.test.js
+++ b/test/commands/scaffold.test.js
@@ -125,6 +125,34 @@ describe('draftwise scaffold', () => {
     expect(out).toContain('npx create-next-app');
   });
 
+  it('blocks file paths that escape the project root', async () => {
+    await seedScaffold(dir, {
+      ...SAMPLE_PLAN,
+      initial_files: [
+        { path: '../escape.txt', purpose: 'should not be written' },
+        { path: '../../../etc/foo.txt', purpose: 'also blocked' },
+        { path: 'src/legit.ts', purpose: 'this one is fine' },
+      ],
+    });
+
+    await scaffoldCommand([], {
+      cwd: dir,
+      log: (m) => logs.push(m),
+      prompts: fakePrompts(true),
+    });
+
+    const out = logs.join('\n');
+    expect(out).toContain('blocked (escapes project root): ../escape.txt');
+    expect(out).toContain('blocked (escapes project root): ../../../etc/foo.txt');
+    expect(out).toContain('+ created: src/legit.ts');
+    expect(out).toMatch(/2 blocked/);
+
+    // Sanity: the legit file landed; the escape attempts didn't.
+    expect(await pathExists(join(dir, 'src/legit.ts'))).toBe(true);
+    // Walk one level up to confirm escape didn't write anything.
+    expect(await pathExists(join(dir, '..', 'escape.txt'))).toBe(false);
+  });
+
   it('skips files that already exist instead of overwriting', async () => {
     await seedScaffold(dir);
     await mkdir(join(dir, 'app'), { recursive: true });


### PR DESCRIPTION
P0 — eslint.config.js. ESLint v10 flat config for an ESM Node CLI. `npm run lint` was outright broken (no config); now it works and caught seven real issues that this PR also fixes:

- five `throw new Error(...)` sites that wrapped a caught error without passing { cause: err } — config.js, two greenfield.js parsers, new.js, and scaffold.js. Inner stacks were lost. Now preserved and recoverable via DRAFTWISE_DEBUG=1.
- two useless `\-` escapes in scanner.js character classes.
- one unused `cwd` arg destructured in runGreenfield.

P1 — Path-traversal guard in scaffold. AI-supplied f.path values were being passed to `join(cwd, f.path)`, which silently followed "../../etc/foo" out of the project root. Now uses
`resolve(cwd, f.path)` and refuses anything that doesn't land under the resolved cwd. Blocked entries log as
"blocked (escapes project root)" and the summary line counts them.

P1 — Tests for src/ai/provider.js (4 paths: unknown provider, missing env var, openai stub, gemini stub) and
src/ai/providers/claude.js (mocked SDK; covers single-block, multi-block ignoring tool_use/thinking, empty content, no-text- blocks, model default of claude-sonnet-4-6, model override, system + messages pass-through, SDK error propagation).

P1 — DRAFTWISE_DEBUG=1 in src/index.js. When set, prints err.stack and any err.cause chain on unexpected errors. Without it, only the message prints with a one-line hint. The user can now actually debug their own bug reports.

P1 — prepublishOnly script. `npm test && npm run lint` runs before publish — main can't ship broken anymore.

Tests: 147/147 passing (was 133, +14 across provider, claude, and
the scaffold traversal case). Lint: clean.

Per docs-sync: CHANGELOG [Unreleased] now records all of the above. README and CLAUDE.md don't change — these are internal hardening, no functional surface shift.