### PR TITLE
Parallelize scanner reads; bump Claude max_tokens to 16384

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Each released version is tagged in git (`v0.0.1`, `v0.1.0`, etc.) and includes t
 ## [Unreleased]
 
 ### Changed
+- **Parallelize per-file reads in scanner detectors.** The eight detector loops (Express/Fastify routes, Mongoose, Drizzle, FastAPI, Flask, Django routes, SQLAlchemy, Django models) used to read files sequentially — fine for small repos, painful on monorepos. Now use a 50-way bounded `mapConcurrent` from new `src/utils/concurrency.js`. Same matches, faster on big trees. — Ankur (#TBD)
+- **Bump default Claude `max_tokens` to 16384 and expose `ai.max_tokens` in config.** The previous 8192 truncated overviews and tech specs on richly-scanned repos. Default raised; users can override via config (or set lower to cap costs). — Ankur (#TBD)
 - **Extract shared `pathExists` and `compactScan` helpers.** The audit's two duplication smells — `pathExists` defined identically in 10 files, `compactScan` defined identically in 4 — now live in `src/utils/fs.js` and `src/utils/scan-projection.js` respectively. Pure refactor; no behavior change. The 14 consumer files import the shared versions and drop their local definitions (and the `access` import that only existed for `pathExists`). Going forward, any tuning to the prompt-sized scan projection happens in one place. Closes audit P2 #1 and #2. — Ankur (#TBD)
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,7 @@ ai:
   provider: claude | openai | gemini  # only if mode: api
   api_key_env: ANTHROPIC_API_KEY      # only if mode: api
   model: ""                            # optional override
+  max_tokens: 16384                    # optional; default 16384. Bumped from 8192 because synthesis calls were truncating on big repos.
 project:
   state: greenfield | brownfield      # set by `draftwise init`; controls prompt routing
   stack: "Next.js + Postgres + Prisma" # greenfield only; the stack the PM picked at init

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -14,7 +14,14 @@ function notImplemented(name) {
   };
 }
 
-export async function complete({ provider, apiKeyEnv, model, system, prompt }) {
+export async function complete({
+  provider,
+  apiKeyEnv,
+  model,
+  system,
+  prompt,
+  maxTokens,
+}) {
   const adapter = ADAPTERS[provider];
   if (!adapter) {
     throw new Error(`Unknown AI provider "${provider}".`);
@@ -25,5 +32,5 @@ export async function complete({ provider, apiKeyEnv, model, system, prompt }) {
       `Environment variable ${apiKeyEnv} is not set. Export it before running this command.`,
     );
   }
-  return adapter({ apiKey, model, system, prompt });
+  return adapter({ apiKey, model, system, prompt, maxTokens });
 }

--- a/src/ai/providers/claude.js
+++ b/src/ai/providers/claude.js
@@ -1,13 +1,16 @@
 import Anthropic from '@anthropic-ai/sdk';
 
 const DEFAULT_MODEL = 'claude-sonnet-4-6';
-const MAX_TOKENS = 8192;
+// Bumped from the previous 8192 — synthesis calls (overview, tech spec,
+// task breakdown) on richly-scanned repos were getting truncated.
+// Override per-config via ai.max_tokens.
+const DEFAULT_MAX_TOKENS = 16384;
 
-export async function complete({ apiKey, model, system, prompt }) {
+export async function complete({ apiKey, model, system, prompt, maxTokens }) {
   const client = new Anthropic({ apiKey });
   const response = await client.messages.create({
     model: model || DEFAULT_MODEL,
-    max_tokens: MAX_TOKENS,
+    max_tokens: maxTokens || DEFAULT_MAX_TOKENS,
     system,
     messages: [{ role: 'user', content: prompt }],
   });

--- a/src/commands/explain.js
+++ b/src/commands/explain.js
@@ -83,6 +83,7 @@ export default async function explainCommand(args = [], deps = {}) {
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
     model: config.model,
+    maxTokens: config.maxTokens,
     system: SYSTEM,
     prompt: buildPrompt({
       flow,

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -128,6 +128,7 @@ export default async function newCommand(args = [], deps = {}) {
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
     model: config.model,
+    maxTokens: config.maxTokens,
     system: selectPlanSystem(config.projectState),
     prompt: buildPlanPrompt({
       idea,
@@ -191,6 +192,7 @@ export default async function newCommand(args = [], deps = {}) {
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
     model: config.model,
+    maxTokens: config.maxTokens,
     system: selectSpecSystem(config.projectState),
     prompt: buildSpecPrompt({
       idea,

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -99,6 +99,7 @@ export default async function scanCommand(_args = [], deps = {}) {
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
     model: config.model,
+    maxTokens: config.maxTokens,
     system: SYSTEM,
     prompt: buildPrompt({ scan: scanForPrompt, packageMeta: result.packageMeta }),
   });

--- a/src/commands/tasks.js
+++ b/src/commands/tasks.js
@@ -146,6 +146,7 @@ export default async function tasksCommand(args = [], deps = {}) {
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
     model: config.model,
+    maxTokens: config.maxTokens,
     system: selectSystem(config.projectState),
     prompt: buildPrompt({
       technicalSpec,

--- a/src/commands/tech.js
+++ b/src/commands/tech.js
@@ -146,6 +146,7 @@ export default async function techCommand(args = [], deps = {}) {
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
     model: config.model,
+    maxTokens: config.maxTokens,
     system: selectSystem(config.projectState),
     prompt: buildPrompt({
       productSpec,

--- a/src/core/scanner.js
+++ b/src/core/scanner.js
@@ -1,5 +1,10 @@
 import { readdir, readFile, access } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
+import { mapConcurrent } from '../utils/concurrency.js';
+
+// Cap concurrent file reads. Far below typical fd limits and high enough
+// to give a meaningful speedup over sequential reads on big repos.
+const READ_CONCURRENCY = 50;
 
 export const IGNORE_DIRS = new Set([
   'node_modules',
@@ -455,28 +460,33 @@ const TEST_FILE_RE = /(?:^|\/)(?:test|tests|__tests__|spec|specs)\/|\.(?:test|sp
 
 async function detectFrameworkRoutes(root, files, out) {
   // Negative lookbehind for @ avoids matching Python decorators like @app.get("/x").
-  const RE = /(?<!@)\b(?:app|router|fastify|koa|server)\s*\.\s*(get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/gi;
   const candidates = files.filter(
     (f) => /\.(?:[mc]?[jt]s)$/.test(f) && !TEST_FILE_RE.test(f),
   );
-  for (const file of candidates) {
+  const RE_SRC = /(?<!@)\b(?:app|router|fastify|koa|server)\s*\.\s*(get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]+)['"`]/gi
+    .source;
+  const perFile = await mapConcurrent(candidates, READ_CONCURRENCY, async (file) => {
     let content;
     try {
       content = await readFile(join(root, file), 'utf8');
     } catch {
-      continue;
+      return [];
     }
-    if (content.length > 200_000) continue;
+    if (content.length > 200_000) return [];
+    const matches = [];
+    const re = new RegExp(RE_SRC, 'gi');
     let m;
-    while ((m = RE.exec(content)) !== null) {
-      out.push({
+    while ((m = re.exec(content)) !== null) {
+      matches.push({
         method: m[1].toUpperCase(),
         path: m[2],
         file,
         source: 'http-call',
       });
     }
-  }
+    return matches;
+  });
+  for (const matches of perFile) out.push(...matches);
 }
 
 async function detectModels(root, files, orms) {
@@ -531,44 +541,50 @@ async function parsePrismaSchema(root) {
 }
 
 async function parseMongoose(root, files) {
-  const out = [];
-  const RE_MODEL = /mongoose\.model\s*\(\s*['"`](\w+)['"`]/g;
-  for (const file of files.filter(
+  const candidates = files.filter(
     (f) => /\.(?:[mc]?[jt]s)$/.test(f) && !TEST_FILE_RE.test(f),
-  )) {
+  );
+  const RE_MODEL_SRC = /mongoose\.model\s*\(\s*['"`](\w+)['"`]/g.source;
+  const perFile = await mapConcurrent(candidates, READ_CONCURRENCY, async (file) => {
     let content;
     try {
       content = await readFile(join(root, file), 'utf8');
     } catch {
-      continue;
+      return [];
     }
-    if (!content.includes('mongoose.model')) continue;
+    if (!content.includes('mongoose.model')) return [];
+    const matches = [];
+    const re = new RegExp(RE_MODEL_SRC, 'g');
     let m;
-    while ((m = RE_MODEL.exec(content)) !== null) {
-      out.push({ name: m[1], file, fields: [], source: 'mongoose' });
+    while ((m = re.exec(content)) !== null) {
+      matches.push({ name: m[1], file, fields: [], source: 'mongoose' });
     }
-  }
-  return out;
+    return matches;
+  });
+  return perFile.flat();
 }
 
 async function parseDrizzle(root, files) {
-  const out = [];
-  const RE = /(?:pgTable|sqliteTable|mysqlTable)\s*\(\s*['"`](\w+)['"`]/g;
-  for (const file of files.filter(
+  const candidates = files.filter(
     (f) => /\.(?:[mc]?[jt]s)$/.test(f) && !TEST_FILE_RE.test(f),
-  )) {
+  );
+  const RE_SRC = /(?:pgTable|sqliteTable|mysqlTable)\s*\(\s*['"`](\w+)['"`]/g.source;
+  const perFile = await mapConcurrent(candidates, READ_CONCURRENCY, async (file) => {
     let content;
     try {
       content = await readFile(join(root, file), 'utf8');
     } catch {
-      continue;
+      return [];
     }
+    const matches = [];
+    const re = new RegExp(RE_SRC, 'g');
     let m;
-    while ((m = RE.exec(content)) !== null) {
-      out.push({ name: m[1], file, fields: [], source: 'drizzle' });
+    while ((m = re.exec(content)) !== null) {
+      matches.push({ name: m[1], file, fields: [], source: 'drizzle' });
     }
-  }
-  return out;
+    return matches;
+  });
+  return perFile.flat();
 }
 
 // ----- Python route detection ---------------------------------------------
@@ -579,168 +595,211 @@ function pythonCandidates(files) {
 
 async function detectFastapiRoutes(root, files, out) {
   // Matches @app.get("/path"), @router.post("/path"), @api.delete(...)
-  const RE = /@(?:\w+)\.(get|post|put|patch|delete|options|head)\s*\(\s*(?:path\s*=\s*)?['"]([^'"]+)['"]/gi;
-  for (const file of pythonCandidates(files)) {
-    let content;
-    try {
-      content = await readFile(join(root, file), 'utf8');
-    } catch {
-      continue;
-    }
-    if (content.length > 200_000) continue;
-    if (!/@\w+\.(get|post|put|patch|delete|options|head)\s*\(/i.test(content)) continue;
-    let m;
-    while ((m = RE.exec(content)) !== null) {
-      out.push({
-        method: m[1].toUpperCase(),
-        path: m[2],
-        file,
-        source: 'fastapi',
-      });
-    }
-  }
+  const RE_SRC = /@(?:\w+)\.(get|post|put|patch|delete|options|head)\s*\(\s*(?:path\s*=\s*)?['"]([^'"]+)['"]/gi
+    .source;
+  const QUICK_CHECK = /@\w+\.(get|post|put|patch|delete|options|head)\s*\(/i;
+  const perFile = await mapConcurrent(
+    pythonCandidates(files),
+    READ_CONCURRENCY,
+    async (file) => {
+      let content;
+      try {
+        content = await readFile(join(root, file), 'utf8');
+      } catch {
+        return [];
+      }
+      if (content.length > 200_000) return [];
+      if (!QUICK_CHECK.test(content)) return [];
+      const matches = [];
+      const re = new RegExp(RE_SRC, 'gi');
+      let m;
+      while ((m = re.exec(content)) !== null) {
+        matches.push({
+          method: m[1].toUpperCase(),
+          path: m[2],
+          file,
+          source: 'fastapi',
+        });
+      }
+      return matches;
+    },
+  );
+  for (const matches of perFile) out.push(...matches);
 }
 
 async function detectFlaskRoutes(root, files, out) {
-  const ROUTE_RE = /@(?:\w+)\.route\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*methods\s*=\s*\[([^\]]+)\])?/g;
-  const SHORT_RE = /@(?:\w+)\.(get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/gi;
-  for (const file of pythonCandidates(files)) {
-    let content;
-    try {
-      content = await readFile(join(root, file), 'utf8');
-    } catch {
-      continue;
-    }
-    if (content.length > 200_000) continue;
-    if (!/@\w+\.(route|get|post|put|patch|delete)\s*\(/i.test(content)) continue;
-
-    let m;
-    while ((m = ROUTE_RE.exec(content)) !== null) {
-      const methods = m[2]
-        ? m[2].split(',').map((s) => s.trim().replace(/['"]/g, '').toUpperCase()).filter(Boolean)
-        : ['GET'];
-      for (const method of methods) {
-        out.push({ method, path: m[1], file, source: 'flask' });
+  const ROUTE_RE_SRC = /@(?:\w+)\.route\s*\(\s*['"]([^'"]+)['"](?:\s*,\s*methods\s*=\s*\[([^\]]+)\])?/g
+    .source;
+  const SHORT_RE_SRC = /@(?:\w+)\.(get|post|put|patch|delete)\s*\(\s*['"]([^'"]+)['"]/gi
+    .source;
+  const QUICK_CHECK = /@\w+\.(route|get|post|put|patch|delete)\s*\(/i;
+  const perFile = await mapConcurrent(
+    pythonCandidates(files),
+    READ_CONCURRENCY,
+    async (file) => {
+      let content;
+      try {
+        content = await readFile(join(root, file), 'utf8');
+      } catch {
+        return [];
       }
-    }
-    while ((m = SHORT_RE.exec(content)) !== null) {
-      out.push({
-        method: m[1].toUpperCase(),
-        path: m[2],
-        file,
-        source: 'flask',
-      });
-    }
-  }
+      if (content.length > 200_000) return [];
+      if (!QUICK_CHECK.test(content)) return [];
+      const matches = [];
+      const routeRe = new RegExp(ROUTE_RE_SRC, 'g');
+      let m;
+      while ((m = routeRe.exec(content)) !== null) {
+        const methods = m[2]
+          ? m[2]
+              .split(',')
+              .map((s) => s.trim().replace(/['"]/g, '').toUpperCase())
+              .filter(Boolean)
+          : ['GET'];
+        for (const method of methods) {
+          matches.push({ method, path: m[1], file, source: 'flask' });
+        }
+      }
+      const shortRe = new RegExp(SHORT_RE_SRC, 'gi');
+      while ((m = shortRe.exec(content)) !== null) {
+        matches.push({
+          method: m[1].toUpperCase(),
+          path: m[2],
+          file,
+          source: 'flask',
+        });
+      }
+      return matches;
+    },
+  );
+  for (const matches of perFile) out.push(...matches);
 }
 
 async function detectDjangoRoutes(root, files, out) {
   // Django defines routes in urls.py via path("foo/", view) or re_path(r"^foo$", view).
   // We pull the literal URL string; the view-name is best-effort.
-  const PATH_RE = /\b(?:re_path|path)\s*\(\s*(?:r?['"])([^'"]+)['"]/g;
-  for (const file of pythonCandidates(files)) {
-    if (!/(?:^|\/)urls\.py$/.test(file)) continue;
+  const PATH_RE_SRC = /\b(?:re_path|path)\s*\(\s*(?:r?['"])([^'"]+)['"]/g.source;
+  const candidates = pythonCandidates(files).filter((f) =>
+    /(?:^|\/)urls\.py$/.test(f),
+  );
+  const perFile = await mapConcurrent(candidates, READ_CONCURRENCY, async (file) => {
     let content;
     try {
       content = await readFile(join(root, file), 'utf8');
     } catch {
-      continue;
+      return [];
     }
-    if (content.length > 200_000) continue;
+    if (content.length > 200_000) return [];
+    const matches = [];
+    const re = new RegExp(PATH_RE_SRC, 'g');
     let m;
-    while ((m = PATH_RE.exec(content)) !== null) {
-      out.push({
+    while ((m = re.exec(content)) !== null) {
+      matches.push({
         method: 'ANY',
         path: m[1].startsWith('/') ? m[1] : '/' + m[1],
         file,
         source: 'django',
       });
     }
-  }
+    return matches;
+  });
+  for (const matches of perFile) out.push(...matches);
 }
 
 // ----- Python model detection ---------------------------------------------
 
 async function parseSqlalchemy(root, files) {
-  const out = [];
-  // class Foo(Base): ... or class Foo(db.Model): ...
-  const CLASS_RE = /^class\s+(\w+)\s*\(([^)]*)\)\s*:/gm;
-  const COLUMN_RE = /^\s{4,}(\w+)\s*(?::\s*[^=]+)?=\s*(?:mapped_column|Column)\s*\(/gm;
+  const CLASS_RE_SRC = /^class\s+(\w+)\s*\(([^)]*)\)\s*:/gm.source;
+  const COLUMN_RE_SRC = /^\s{4,}(\w+)\s*(?::\s*[^=]+)?=\s*(?:mapped_column|Column)\s*\(/gm
+    .source;
   const TABLE_RE = /__tablename__\s*=\s*['"]([^'"]+)['"]/;
-  for (const file of pythonCandidates(files)) {
-    let content;
-    try {
-      content = await readFile(join(root, file), 'utf8');
-    } catch {
-      continue;
-    }
-    if (content.length > 200_000) continue;
-    if (!/sqlalchemy|declarative_base|DeclarativeBase|Mapped|db\.Model/.test(content)) continue;
-    let m;
-    while ((m = CLASS_RE.exec(content)) !== null) {
-      const baseList = m[2];
-      const isModel = /\bBase\b|\bDeclarativeBase\b|db\.Model|\bModel\b/.test(baseList);
-      if (!isModel) continue;
-      // find the class body (rough — until next top-level "class " or end of file)
-      const start = m.index + m[0].length;
-      const remainder = content.slice(start);
-      const next = remainder.search(/^class\s+\w+\s*\(/m);
-      const body = next >= 0 ? remainder.slice(0, next) : remainder;
-      const fields = [];
-      let f;
-      const localCol = new RegExp(COLUMN_RE.source, 'gm');
-      while ((f = localCol.exec(body)) !== null) {
-        if (!fields.includes(f[1])) fields.push(f[1]);
-        if (fields.length >= 10) break;
+  const QUICK_CHECK = /sqlalchemy|declarative_base|DeclarativeBase|Mapped|db\.Model/;
+  const perFile = await mapConcurrent(
+    pythonCandidates(files),
+    READ_CONCURRENCY,
+    async (file) => {
+      let content;
+      try {
+        content = await readFile(join(root, file), 'utf8');
+      } catch {
+        return [];
       }
-      const tableMatch = body.match(TABLE_RE);
-      out.push({
-        name: m[1],
-        file,
-        fields,
-        tableName: tableMatch ? tableMatch[1] : undefined,
-        source: 'sqlalchemy',
-      });
-    }
-  }
-  return out;
+      if (content.length > 200_000) return [];
+      if (!QUICK_CHECK.test(content)) return [];
+      const matches = [];
+      const classRe = new RegExp(CLASS_RE_SRC, 'gm');
+      let m;
+      while ((m = classRe.exec(content)) !== null) {
+        const baseList = m[2];
+        const isModel = /\bBase\b|\bDeclarativeBase\b|db\.Model|\bModel\b/.test(
+          baseList,
+        );
+        if (!isModel) continue;
+        // find the class body (rough — until next top-level "class " or end of file)
+        const start = m.index + m[0].length;
+        const remainder = content.slice(start);
+        const next = remainder.search(/^class\s+\w+\s*\(/m);
+        const body = next >= 0 ? remainder.slice(0, next) : remainder;
+        const fields = [];
+        const localCol = new RegExp(COLUMN_RE_SRC, 'gm');
+        let f;
+        while ((f = localCol.exec(body)) !== null) {
+          if (!fields.includes(f[1])) fields.push(f[1]);
+          if (fields.length >= 10) break;
+        }
+        const tableMatch = body.match(TABLE_RE);
+        matches.push({
+          name: m[1],
+          file,
+          fields,
+          tableName: tableMatch ? tableMatch[1] : undefined,
+          source: 'sqlalchemy',
+        });
+      }
+      return matches;
+    },
+  );
+  return perFile.flat();
 }
 
 async function parseDjangoModels(root, files) {
-  const out = [];
-  const CLASS_RE = /^class\s+(\w+)\s*\(([^)]*)\)\s*:/gm;
-  const FIELD_RE = /^\s{4,}(\w+)\s*=\s*models\.\w+/gm;
-  for (const file of pythonCandidates(files)) {
-    if (!/(?:^|\/)models(?:\.py|\/)/.test(file)) continue;
+  const CLASS_RE_SRC = /^class\s+(\w+)\s*\(([^)]*)\)\s*:/gm.source;
+  const FIELD_RE_SRC = /^\s{4,}(\w+)\s*=\s*models\.\w+/gm.source;
+  const candidates = pythonCandidates(files).filter((f) =>
+    /(?:^|\/)models(?:\.py|\/)/.test(f),
+  );
+  const perFile = await mapConcurrent(candidates, READ_CONCURRENCY, async (file) => {
     let content;
     try {
       content = await readFile(join(root, file), 'utf8');
     } catch {
-      continue;
+      return [];
     }
-    if (content.length > 200_000) continue;
-    if (!/models\.Model/.test(content)) continue;
+    if (content.length > 200_000) return [];
+    if (!/models\.Model/.test(content)) return [];
+    const matches = [];
+    const classRe = new RegExp(CLASS_RE_SRC, 'gm');
     let m;
-    while ((m = CLASS_RE.exec(content)) !== null) {
+    while ((m = classRe.exec(content)) !== null) {
       if (!/models\.Model/.test(m[2])) continue;
       const start = m.index + m[0].length;
       const remainder = content.slice(start);
       const next = remainder.search(/^class\s+\w+\s*\(/m);
       const body = next >= 0 ? remainder.slice(0, next) : remainder;
       const fields = [];
+      const localField = new RegExp(FIELD_RE_SRC, 'gm');
       let f;
-      const localField = new RegExp(FIELD_RE.source, 'gm');
       while ((f = localField.exec(body)) !== null) {
         if (!fields.includes(f[1])) fields.push(f[1]);
         if (fields.length >= 10) break;
       }
-      out.push({
+      matches.push({
         name: m[1],
         file,
         fields,
         source: 'django',
       });
     }
-  }
-  return out;
+    return matches;
+  });
+  return perFile.flat();
 }

--- a/src/utils/concurrency.js
+++ b/src/utils/concurrency.js
@@ -1,0 +1,20 @@
+// Run an async function over a list with a concurrency cap. Returns the
+// results in input order. Used by the scanner detectors so a monorepo
+// with thousands of source files doesn't open a file descriptor for
+// every match at once.
+export async function mapConcurrent(items, limit, fn) {
+  const results = new Array(items.length);
+  let next = 0;
+
+  async function worker() {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i], i);
+    }
+  }
+
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  await Promise.all(Array.from({ length: workerCount }, worker));
+  return results;
+}

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -57,11 +57,17 @@ export async function loadConfig(cwd = process.cwd()) {
     scanMaxFiles = Math.max(1, Math.floor(scan.max_files));
   }
 
+  let maxTokens;
+  if (typeof ai.max_tokens === 'number' && Number.isFinite(ai.max_tokens)) {
+    maxTokens = Math.max(1, Math.floor(ai.max_tokens));
+  }
+
   return {
     mode: ai.mode,
     provider: ai.provider,
     apiKeyEnv: ai.api_key_env,
     model: ai.model || '',
+    maxTokens,
     projectState,
     stack: project.stack,
     scanMaxFiles,

--- a/test/ai/providers/claude.test.js
+++ b/test/ai/providers/claude.test.js
@@ -107,6 +107,24 @@ describe('ai/providers/claude — complete()', () => {
     expect(call.max_tokens).toBeGreaterThan(0);
   });
 
+  it('uses 16384 as the default max_tokens (synthesis-friendly)', async () => {
+    createMock.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    await complete({ apiKey: 'sk', model: '', system: 's', prompt: 'p' });
+    expect(createMock.mock.calls.at(-1)[0].max_tokens).toBe(16384);
+  });
+
+  it('respects an explicit maxTokens override', async () => {
+    createMock.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    await complete({
+      apiKey: 'sk',
+      model: '',
+      system: 's',
+      prompt: 'p',
+      maxTokens: 4096,
+    });
+    expect(createMock.mock.calls.at(-1)[0].max_tokens).toBe(4096);
+  });
+
   it('propagates SDK errors so callers can handle them', async () => {
     createMock.mockRejectedValue(new Error('429 Too Many Requests'));
     await expect(

--- a/test/utils/concurrency.test.js
+++ b/test/utils/concurrency.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { mapConcurrent } from '../../src/utils/concurrency.js';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+describe('mapConcurrent', () => {
+  it('returns results in input order', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const out = await mapConcurrent(items, 3, async (n) => n * 2);
+    expect(out).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('respects the concurrency cap', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 20 }, (_, i) => i);
+    await mapConcurrent(items, 4, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await sleep(5);
+      inFlight--;
+    });
+    expect(peak).toBeLessThanOrEqual(4);
+  });
+
+  it('handles an empty input', async () => {
+    expect(await mapConcurrent([], 5, async () => 1)).toEqual([]);
+  });
+
+  it('caps workers to items.length when limit exceeds it', async () => {
+    let peak = 0;
+    let inFlight = 0;
+    await mapConcurrent([1, 2], 10, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await sleep(2);
+      inFlight--;
+    });
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  it('passes the index as the second arg to the worker', async () => {
+    const out = await mapConcurrent(['a', 'b', 'c'], 2, async (item, i) => `${item}${i}`);
+    expect(out).toEqual(['a0', 'b1', 'c2']);
+  });
+
+  it('propagates errors from the worker', async () => {
+    await expect(
+      mapConcurrent([1, 2, 3], 2, async (n) => {
+        if (n === 2) throw new Error('boom');
+        return n;
+      }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/test/utils/config.test.js
+++ b/test/utils/config.test.js
@@ -28,8 +28,10 @@ describe('loadConfig', () => {
       provider: undefined,
       apiKeyEnv: undefined,
       model: '',
+      maxTokens: undefined,
       projectState: 'brownfield',
       stack: undefined,
+      scanMaxFiles: undefined,
     });
   });
 
@@ -82,6 +84,26 @@ describe('loadConfig', () => {
     );
     const config = await loadConfig(dir);
     expect(config.scanMaxFiles).toBe(250);
+  });
+
+  it('parses ai.max_tokens when set', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: agent\n  max_tokens: 32000\n',
+      'utf8',
+    );
+    const config = await loadConfig(dir);
+    expect(config.maxTokens).toBe(32000);
+  });
+
+  it('leaves maxTokens undefined when not set (adapter falls back to default)', async () => {
+    await writeFile(
+      join(dir, '.draftwise', 'config.yaml'),
+      'ai:\n  mode: agent\n',
+      'utf8',
+    );
+    const config = await loadConfig(dir);
+    expect(config.maxTokens).toBeUndefined();
   });
 
   it('reads api mode config with provider and api_key_env', async () => {


### PR DESCRIPTION
The scanner's per-file detectors used to read sequentially — 50ms × 200 files = noticeable wait on monorepos. New util src/utils/concurrency.js does bounded-concurrency mapping; the eight detectors (JS routes, Mongoose, Drizzle, FastAPI, Flask, Django routes/models, SQLAlchemy) now run 50 reads in flight. Same matches in the same order — pure perf change.

While in there: max_tokens default goes from 8192 to 16384 and becomes configurable via ai.max_tokens in config.yaml. The old default was truncating richly-scanned overviews and tech specs. Default applies if config doesn't set it; init's setup calls fall through to the default since they happen before config exists.

Closes audit P2 #3 and #5.