### PR TITLE
Harden the last three audit P2s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Test on the engines.node floor and the current LTS.
+        node: ['20', '22']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ Each released version is tagged in git (`v0.0.1`, `v0.1.0`, etc.) and includes t
 
 ## [Unreleased]
 
+### Added
+- **CI workflow.** `.github/workflows/ci.yml` runs `npm ci`, `npm run lint`, and `npm test` on every PR and on pushes to `main`, against Node 20 and Node 22. Manual test-runs before merge are no longer the only safety net. — Ankur (#TBD)
+- **Cache schema version.** `.draftwise/.cache/scan.json` now carries a `cacheVersion` field; mismatched versions are treated as a cache-miss instead of returning stale-shape data. Bump `CACHE_VERSION` in `src/utils/scan-cache.js` whenever scan output shape changes. — Ankur (#TBD)
+
 ### Changed
+- **Bump Anthropic SDK retry budget from 2 to 4.** The SDK already retries on 429 / 5xx / network errors; we just give it a more generous default than ours used. Less hand-holding needed for transient blips. — Ankur (#TBD)
 - **Parallelize per-file reads in scanner detectors.** The eight detector loops (Express/Fastify routes, Mongoose, Drizzle, FastAPI, Flask, Django routes, SQLAlchemy, Django models) used to read files sequentially — fine for small repos, painful on monorepos. Now use a 50-way bounded `mapConcurrent` from new `src/utils/concurrency.js`. Same matches, faster on big trees. — Ankur (#TBD)
 - **Bump default Claude `max_tokens` to 16384 and expose `ai.max_tokens` in config.** The previous 8192 truncated overviews and tech specs on richly-scanned repos. Default raised; users can override via config (or set lower to cap costs). — Ankur (#TBD)
 - **Extract shared `pathExists` and `compactScan` helpers.** The audit's two duplication smells — `pathExists` defined identically in 10 files, `compactScan` defined identically in 4 — now live in `src/utils/fs.js` and `src/utils/scan-projection.js` respectively. Pure refactor; no behavior change. The 14 consumer files import the shared versions and drop their local definitions (and the `access` import that only existed for `pathExists`). Going forward, any tuning to the prompt-sized scan projection happens in one place. Closes audit P2 #1 and #2. — Ankur (#TBD)

--- a/src/ai/providers/claude.js
+++ b/src/ai/providers/claude.js
@@ -6,8 +6,12 @@ const DEFAULT_MODEL = 'claude-sonnet-4-6';
 // Override per-config via ai.max_tokens.
 const DEFAULT_MAX_TOKENS = 16384;
 
+// SDK's default is 2 retries on 429 / 5xx / network errors. 4 covers
+// most transient issues without making rate-limit waits feel hung.
+const MAX_RETRIES = 4;
+
 export async function complete({ apiKey, model, system, prompt, maxTokens }) {
-  const client = new Anthropic({ apiKey });
+  const client = new Anthropic({ apiKey, maxRetries: MAX_RETRIES });
   const response = await client.messages.create({
     model: model || DEFAULT_MODEL,
     max_tokens: maxTokens || DEFAULT_MAX_TOKENS,

--- a/src/utils/scan-cache.js
+++ b/src/utils/scan-cache.js
@@ -10,6 +10,11 @@ import {
 
 const CACHE_REL_PATH = ['.draftwise', '.cache', 'scan.json'];
 
+// Bump this when the scan result shape changes (new field, renamed key,
+// removed field). Old cache entries with a different version are
+// treated as cache-miss instead of returning stale-shape data.
+const CACHE_VERSION = 1;
+
 function cachePath(root) {
   return join(root, ...CACHE_REL_PATH);
 }
@@ -27,12 +32,17 @@ export async function cachedScan(root, options = {}) {
   const path = cachePath(root);
   const cached = await readCache(path);
 
-  if (cached && cached.fingerprint === fingerprint) {
+  if (
+    cached &&
+    cached.cacheVersion === CACHE_VERSION &&
+    cached.fingerprint === fingerprint
+  ) {
     return { ...cached.result, fromCache: true };
   }
 
   const fresh = await scan(root, { maxFiles });
   await writeCache(path, {
+    cacheVersion: CACHE_VERSION,
     fingerprint,
     savedAt: new Date().toISOString(),
     result: fresh,

--- a/test/ai/providers/claude.test.js
+++ b/test/ai/providers/claude.test.js
@@ -2,10 +2,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock @anthropic-ai/sdk before importing claude.js — vi.mock is hoisted.
 const createMock = vi.fn();
+const constructorOpts = [];
 vi.mock('@anthropic-ai/sdk', () => {
   // The SDK's default export is a class; new-ing it must work.
   class FakeAnthropic {
-    constructor() {
+    constructor(opts) {
+      constructorOpts.push(opts);
       this.messages = { create: createMock };
     }
   }
@@ -17,6 +19,7 @@ const { complete } = await import('../../../src/ai/providers/claude.js');
 describe('ai/providers/claude — complete()', () => {
   beforeEach(() => {
     createMock.mockReset();
+    constructorOpts.length = 0;
   });
 
   it('returns concatenated text from a single text block', async () => {
@@ -123,6 +126,14 @@ describe('ai/providers/claude — complete()', () => {
       maxTokens: 4096,
     });
     expect(createMock.mock.calls.at(-1)[0].max_tokens).toBe(4096);
+  });
+
+  it('configures the SDK with a generous retry budget for transient failures', async () => {
+    createMock.mockResolvedValue({ content: [{ type: 'text', text: 'ok' }] });
+    await complete({ apiKey: 'sk', model: '', system: 's', prompt: 'p' });
+    expect(constructorOpts.at(-1)).toEqual(
+      expect.objectContaining({ apiKey: 'sk', maxRetries: 4 }),
+    );
   });
 
   it('propagates SDK errors so callers can handle them', async () => {

--- a/test/utils/scan-cache.test.js
+++ b/test/utils/scan-cache.test.js
@@ -121,6 +121,32 @@ describe('cachedScan', () => {
     expect(calls).toBe(3);
   });
 
+  it('treats a cache from an older schema version as a miss', async () => {
+    await seedRepo(dir);
+    let calls = 0;
+    const fakeScan = async () => {
+      calls++;
+      return { files: ['src/a.js'], frameworks: [], routes: [], components: [], models: [], packageMeta: {} };
+    };
+
+    // Run once to populate a real cache, then mutate cacheVersion to 0
+    // (simulating a cache written by an older draftwise build).
+    await cachedScan(dir, { scan: fakeScan });
+    const cacheFile = join(dir, '.draftwise', '.cache', 'scan.json');
+    const stale = JSON.parse(await readFile(cacheFile, 'utf8'));
+    stale.cacheVersion = 0;
+    await writeFile(cacheFile, JSON.stringify(stale), 'utf8');
+
+    // The next call should miss (calls increments) and rewrite with v1.
+    const before = calls;
+    const result = await cachedScan(dir, { scan: fakeScan });
+    expect(calls).toBe(before + 1);
+    expect(result.fromCache).toBe(false);
+
+    const refreshed = JSON.parse(await readFile(cacheFile, 'utf8'));
+    expect(refreshed.cacheVersion).toBe(1);
+  });
+
   it('survives a corrupt cache file by re-scanning', async () => {
     await seedRepo(dir);
     await mkdir(join(dir, '.draftwise', '.cache'), { recursive: true });


### PR DESCRIPTION
CI workflow at .github/workflows/ci.yml — install + lint + test on Node 20 and 22, on every PR and push to main. Manual checks before merge stop being the only line of defense.

Anthropic SDK maxRetries goes from its default 2 to 4. The SDK already handles 429 / 5xx / network retries internally; the audit suggested wrapping our own retry but that's redundant with existing SDK behavior. Bumping the SDK's own knob covers more transient blips with less code.

scan-cache.json gains a cacheVersion field. When we change scan output shape later (new field, renamed key), bumping CACHE_VERSION in src/utils/scan-cache.js makes old caches miss instead of poisoning downstream commands with stale shapes.
