### PR TITLE
Polish: --version, per-command --help, .prettierrc, exact SDK pin

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true,
+  "tabWidth": 2,
+  "printWidth": 80,
+  "endOfLine": "lf",
+  "arrowParens": "always"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ Each released version is tagged in git (`v0.0.1`, `v0.1.0`, etc.) and includes t
 ## [Unreleased]
 
 ### Added
+- **`--version` / `-v` flag** on the CLI, prints the installed package version. — Ankur (#TBD)
+- **Per-command `--help` / `-h`.** Each command now exports a `HELP` string with usage and examples; the router shows it when `--help` follows the command name. The "coming soon" placeholder is gone. — Ankur (#TBD)
+- **`.prettierrc`** — explicit Prettier defaults (singleQuote, trailingComma all, semi, printWidth 80, eol lf). Matches the existing code shape; makes formatting reproducible across machines. — Ankur (#TBD)
 - **CI workflow.** `.github/workflows/ci.yml` runs `npm ci`, `npm run lint`, and `npm test` on every PR and on pushes to `main`, against Node 20 and Node 22. Manual test-runs before merge are no longer the only safety net. — Ankur (#TBD)
 - **Cache schema version.** `.draftwise/.cache/scan.json` now carries a `cacheVersion` field; mismatched versions are treated as a cache-miss instead of returning stale-shape data. Bump `CACHE_VERSION` in `src/utils/scan-cache.js` whenever scan output shape changes. — Ankur (#TBD)
 
 ### Changed
+- **Pin `@anthropic-ai/sdk` to exact version (was `^0.91.1`).** A 0.x caret allows minor bumps that the SDK's own semver doesn't promise to keep non-breaking; pinning exact removes the risk of a quiet `npm install` upgrading us into a breakage. Bump manually when ready. — Ankur (#TBD)
 - **Bump Anthropic SDK retry budget from 2 to 4.** The SDK already retries on 429 / 5xx / network errors; we just give it a more generous default than ours used. Less hand-holding needed for transient blips. — Ankur (#TBD)
 - **Parallelize per-file reads in scanner detectors.** The eight detector loops (Express/Fastify routes, Mongoose, Drizzle, FastAPI, Flask, Django routes, SQLAlchemy, Django models) used to read files sequentially — fine for small repos, painful on monorepos. Now use a 50-way bounded `mapConcurrent` from new `src/utils/concurrency.js`. Same matches, faster on big trees. — Ankur (#TBD)
 - **Bump default Claude `max_tokens` to 16384 and expose `ai.max_tokens` in config.** The previous 8192 truncated overviews and tech specs on richly-scanned repos. Default raised; users can override via config (or set lower to cap costs). — Ankur (#TBD)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.91.1",
+        "@anthropic-ai/sdk": "0.91.1",
         "@inquirer/prompts": "^8.4.2",
         "yaml": "^2.8.3"
       },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.91.1",
+    "@anthropic-ai/sdk": "0.91.1",
     "@inquirer/prompts": "^8.4.2",
     "yaml": "^2.8.3"
   },

--- a/src/commands/explain.js
+++ b/src/commands/explain.js
@@ -10,6 +10,20 @@ import { compactScan } from '../utils/scan-projection.js';
 import { SYSTEM, buildPrompt, buildAgentInstruction } from '../ai/prompts/explain.js';
 import { slugify } from '../utils/slug.js';
 
+export const HELP = `draftwise explain <flow> — trace a flow through the codebase
+
+Usage:
+  draftwise explain "<flow name>"
+  draftwise explain checkout
+  draftwise explain "user signup"
+
+Walks the flow end-to-end: entry points, services, data writes,
+side effects, edge cases the code handles. The scan is filtered
+to flow-keyword-relevant files so the model focuses on what
+matters. Saves a snapshot to .draftwise/flows/<slug>.md in api
+mode. Brownfield only — greenfield short-circuits with a hint.
+`;
+
 export default async function explainCommand(args = [], deps = {}) {
   const cwd = deps.cwd ?? process.cwd();
   const log = deps.log ?? ((msg) => console.log(msg));

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -17,6 +17,17 @@ import {
   buildAgentInstruction as buildGreenfieldAgentInstruction,
 } from '../ai/prompts/greenfield.js';
 
+export const HELP = `draftwise init — set up .draftwise/ for the current project
+
+Usage:
+  draftwise init
+
+Asks whether the project is greenfield (no code yet) or brownfield
+(existing codebase) and routes accordingly. Greenfield walks you
+through stack selection with rationale, pros, and cons. Brownfield
+scans the codebase. Refuses to overwrite an existing .draftwise/.
+`;
+
 const ENV_VAR_BY_PROVIDER = {
   claude: 'ANTHROPIC_API_KEY',
   openai: 'OPENAI_API_KEY',

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -3,6 +3,16 @@ import { join } from 'node:path';
 import { listSpecs as defaultListSpecs } from '../utils/specs.js';
 import { pathExists } from '../utils/fs.js';
 
+export const HELP = `draftwise list — list all specs in .draftwise/specs/
+
+Usage:
+  draftwise list
+
+Three columns: slug, status (which artifacts exist —
+product · tech · tasks), and the title from product-spec.md's H1.
+Empty spec dirs show as "(empty)".
+`;
+
 async function readTitle(file) {
   try {
     const content = await readFile(file, 'utf8');

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -18,6 +18,24 @@ import {
 } from '../ai/prompts/new.js';
 import { slugify } from '../utils/slug.js';
 
+export const HELP = `draftwise new "<idea>" — conversational product-spec drafting
+
+Usage:
+  draftwise new "<your feature idea>"
+  draftwise new "add collaborative albums"
+  draftwise new "let users mute notifications"
+
+Three phases:
+  1. AI plans the conversation — clarifying questions tailored to
+     your repo (or your greenfield plan), affected flows, and
+     adjacent opportunities.
+  2. You walk through questions and accept/decline opportunities.
+  3. AI synthesizes a product-spec.md under .draftwise/specs/<slug>/.
+
+Hard rule: every claim grounds in scanner output (brownfield) or
+the project plan (greenfield). Never invents files.
+`;
+
 const DEFAULT_PROMPTS = {
   askQuestion: ({ index, total, text, why }) =>
     input({

--- a/src/commands/scaffold.js
+++ b/src/commands/scaffold.js
@@ -3,6 +3,18 @@ import { join, dirname, resolve, sep } from 'node:path';
 import { confirm } from '@inquirer/prompts';
 import { pathExists } from '../utils/fs.js';
 
+export const HELP = `draftwise scaffold — create initial files from a greenfield plan
+
+Usage:
+  draftwise scaffold
+
+Reads .draftwise/scaffold.json (written by \`draftwise init\` in
+greenfield mode), confirms before writing, then creates each
+initial_files entry with placeholder content. Skips files that
+already exist. Refuses paths that escape the project root. Does
+NOT run setup commands — they're printed for manual execution.
+`;
+
 const DEFAULT_PROMPTS = {
   confirmScaffold: ({ stack, fileCount }) =>
     confirm({

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -7,6 +7,18 @@ import { describeScanWarnings } from '../utils/scan-warnings.js';
 import { pathExists } from '../utils/fs.js';
 import { SYSTEM, buildPrompt, AGENT_INSTRUCTION } from '../ai/prompts/scan.js';
 
+export const HELP = `draftwise scan — refresh the codebase overview (brownfield)
+
+Usage:
+  draftwise scan
+
+Re-runs the scanner. In api mode, calls your AI provider to write
+a narrated overview to .draftwise/overview.md. In agent mode,
+prints scanner data + an instruction for the host coding agent.
+In a greenfield project, prints a friendly hint and exits — the
+plan from \`draftwise init\` is already in overview.md.
+`;
+
 function summarize(scan) {
   return {
     files: scan.files.length,

--- a/src/commands/show.js
+++ b/src/commands/show.js
@@ -3,6 +3,18 @@ import { join } from 'node:path';
 import { listSpecs as defaultListSpecs } from '../utils/specs.js';
 import { pathExists } from '../utils/fs.js';
 
+export const HELP = `draftwise show <feature> [type] — print a spec to terminal
+
+Usage:
+  draftwise show <feature>             # default type: product
+  draftwise show <feature> tech
+  draftwise show <feature> tasks
+
+Type must be one of: product, tech, tasks. Errors with a hint if
+the requested type hasn't been generated yet (e.g., asking for
+tech before \`draftwise tech\` has run).
+`;
+
 const VALID_TYPES = ['product', 'tech', 'tasks'];
 
 const TYPE_TO_FILE = {

--- a/src/commands/tasks.js
+++ b/src/commands/tasks.js
@@ -15,6 +15,18 @@ import {
   buildAgentInstruction,
 } from '../ai/prompts/tasks.js';
 
+export const HELP = `draftwise tasks [<feature>] — break technical spec into ordered work
+
+Usage:
+  draftwise tasks                 # auto-pick if exactly one tech spec exists
+  draftwise tasks <feature-slug>  # target a specific feature
+
+Generates tasks.md: numbered tasks with Goal / Files / Depends on /
+Parallel with / Acceptance, ordered so each task's dependencies
+appear before it. In greenfield, the first 1-3 tasks are project
+scaffolding (run setup commands, install deps).
+`;
+
 const DEFAULT_PROMPTS = {
   pickSpec: ({ specs }) =>
     select({

--- a/src/commands/tech.js
+++ b/src/commands/tech.js
@@ -15,6 +15,19 @@ import {
   buildAgentInstruction,
 } from '../ai/prompts/tech.js';
 
+export const HELP = `draftwise tech [<feature>] — draft technical-spec.md from a product spec
+
+Usage:
+  draftwise tech                 # auto-pick if exactly one product spec exists
+  draftwise tech <feature-slug>  # target a specific feature
+  draftwise tech                 # multi-spec → inquirer picker
+
+Reads the product spec, writes technical-spec.md grounded in the
+real codebase (brownfield) or the planned directory structure
+(greenfield, with "(new)" markers). Existing technical-spec.md
+gets overwritten — flagged in the picker.
+`;
+
 const DEFAULT_PROMPTS = {
   pickSpec: ({ specs }) =>
     select({

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,9 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
+const VERSION = pkg.version;
+
 const COMMANDS = {
   init: () => import('./commands/init.js'),
   scan: () => import('./commands/scan.js'),
@@ -26,14 +32,27 @@ Commands:
   list                          List all specs in .draftwise/specs/
   show <feature> [type]         Show a spec (type: product | tech | tasks; default: product)
 
-Run "draftwise <command> --help" for command-specific help (coming soon).
+Flags:
+  -h, --help                    Show this help (or per-command help when after a command)
+  -v, --version                 Print the installed draftwise version
+
+Set DRAFTWISE_DEBUG=1 for stack traces on unexpected errors.
 `;
+
+function asksForHelp(args) {
+  return args.includes('--help') || args.includes('-h');
+}
 
 export default async function run(argv) {
   const [cmd, ...rest] = argv;
 
   if (!cmd || cmd === '-h' || cmd === '--help' || cmd === 'help') {
     console.log(HELP);
+    return;
+  }
+
+  if (cmd === '-v' || cmd === '--version' || cmd === 'version') {
+    console.log(VERSION);
     return;
   }
 
@@ -46,6 +65,10 @@ export default async function run(argv) {
 
   try {
     const mod = await loader();
+    if (asksForHelp(rest)) {
+      console.log(mod.HELP || `(no help available for "${cmd}")`);
+      return;
+    }
     await mod.default(rest);
   } catch (err) {
     if (process.env.DRAFTWISE_DEBUG === '1') {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import run from '../src/index.js';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const pkg = require('../package.json');
+
+describe('draftwise CLI router', () => {
+  let logs;
+  let errs;
+  let exitCalls;
+  let originalLog;
+  let originalErr;
+  let originalExit;
+
+  beforeEach(() => {
+    logs = [];
+    errs = [];
+    exitCalls = [];
+    originalLog = console.log;
+    originalErr = console.error;
+    originalExit = process.exit;
+    console.log = (...args) => logs.push(args.join(' '));
+    console.error = (...args) => errs.push(args.join(' '));
+    process.exit = (code) => {
+      exitCalls.push(code);
+      // Throw so the rest of run() doesn't keep executing in tests.
+      throw new Error(`__exit__:${code}`);
+    };
+  });
+
+  afterEach(() => {
+    console.log = originalLog;
+    console.error = originalErr;
+    process.exit = originalExit;
+  });
+
+  it('prints the package.json version for --version', async () => {
+    await run(['--version']);
+    expect(logs.join('\n')).toBe(pkg.version);
+  });
+
+  it('prints the version for -v as well', async () => {
+    await run(['-v']);
+    expect(logs.join('\n')).toBe(pkg.version);
+  });
+
+  it('prints the version for the bare "version" command', async () => {
+    await run(['version']);
+    expect(logs.join('\n')).toBe(pkg.version);
+  });
+
+  it('prints top-level HELP when called with no args', async () => {
+    await run([]);
+    expect(logs.join('\n')).toContain('codebase-aware spec drafting');
+    expect(logs.join('\n')).toContain('--version');
+  });
+
+  it('prints per-command HELP when called with --help after a command', async () => {
+    await run(['init', '--help']);
+    expect(logs.join('\n')).toContain('draftwise init');
+    expect(logs.join('\n')).toContain('greenfield');
+  });
+
+  it('prints per-command HELP for -h after a command', async () => {
+    await run(['explain', '-h']);
+    expect(logs.join('\n')).toContain('draftwise explain');
+    expect(logs.join('\n')).toContain('Walks the flow');
+  });
+
+  it('exits non-zero on unknown commands and shows top-level HELP', async () => {
+    await expect(run(['bogus'])).rejects.toThrow(/__exit__:1/);
+    expect(errs.join('\n')).toContain('Unknown command: bogus');
+  });
+});


### PR DESCRIPTION
CLI gained --version / -v / version, reading from package.json. Each command file now exports a HELP string with usage + a real example or two; the router prints it when --help / -h follows the command. The "coming soon" placeholder in top-level help is gone.

.prettierrc makes formatting explicit (singleQuote, trailingComma all, semi, eol lf). Matches the existing code shape — pure reproducibility win.

@anthropic-ai/sdk pinned to 0.91.1 exact (was ^0.91.1). 0.x caret allowed minor bumps that the SDK doesn't guarantee to keep non-breaking; manual upgrades only now.
