### PR TITLE
Stream Claude synthesis calls token-by-token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Each released version is tagged in git (`v0.0.1`, `v0.1.0`, etc.) and includes t
 ## [Unreleased]
 
 ### Added
+- **Live token streaming for synthesis calls.** `scan`, `explain`, `new` (spec phase), `tech`, and `tasks` now stream the model's output to stdout token-by-token via the Anthropic SDK's `messages.stream()` API. The 10–30s "Synthesizing..." pause is replaced with live output you can read as it generates. JSON / plan calls (init questions, init stacks, new plan) keep the non-streaming path because rendering JSON token-by-token would be worse UX. — Ankur (#TBD)
 - **`--version` / `-v` flag** on the CLI, prints the installed package version. — Ankur (#TBD)
 - **Per-command `--help` / `-h`.** Each command now exports a `HELP` string with usage and examples; the router shows it when `--help` follows the command name. The "coming soon" placeholder is gone. — Ankur (#TBD)
 - **`.prettierrc`** — explicit Prettier defaults (singleQuote, trailingComma all, semi, printWidth 80, eol lf). Matches the existing code shape; makes formatting reproducible across machines. — Ankur (#TBD)

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -21,6 +21,7 @@ export async function complete({
   system,
   prompt,
   maxTokens,
+  onToken,
 }) {
   const adapter = ADAPTERS[provider];
   if (!adapter) {
@@ -32,5 +33,5 @@ export async function complete({
       `Environment variable ${apiKeyEnv} is not set. Export it before running this command.`,
     );
   }
-  return adapter({ apiKey, model, system, prompt, maxTokens });
+  return adapter({ apiKey, model, system, prompt, maxTokens, onToken });
 }

--- a/src/ai/providers/claude.js
+++ b/src/ai/providers/claude.js
@@ -10,20 +10,50 @@ const DEFAULT_MAX_TOKENS = 16384;
 // most transient issues without making rate-limit waits feel hung.
 const MAX_RETRIES = 4;
 
-export async function complete({ apiKey, model, system, prompt, maxTokens }) {
+export async function complete({
+  apiKey,
+  model,
+  system,
+  prompt,
+  maxTokens,
+  onToken,
+}) {
   const client = new Anthropic({ apiKey, maxRetries: MAX_RETRIES });
-  const response = await client.messages.create({
+  const params = {
     model: model || DEFAULT_MODEL,
     max_tokens: maxTokens || DEFAULT_MAX_TOKENS,
     system,
     messages: [{ role: 'user', content: prompt }],
-  });
+  };
 
+  // Streaming path — feed text deltas to onToken as they arrive, accumulate
+  // for the return value. Used by the synthesis commands so users see
+  // output live instead of waiting on a frozen line.
+  if (typeof onToken === 'function') {
+    let accumulated = '';
+    const stream = client.messages.stream(params);
+    for await (const event of stream) {
+      if (
+        event.type === 'content_block_delta' &&
+        event.delta?.type === 'text_delta'
+      ) {
+        accumulated += event.delta.text;
+        onToken(event.delta.text);
+      }
+    }
+    if (!accumulated) {
+      throw new Error('Claude returned an empty response.');
+    }
+    return accumulated;
+  }
+
+  // Non-streaming path — used for JSON / plan calls where live token
+  // display would be worse UX than just waiting for the parsed object.
+  const response = await client.messages.create(params);
   const text = response.content
     .filter((block) => block.type === 'text')
     .map((block) => block.text)
     .join('');
-
   if (!text) {
     throw new Error('Claude returned an empty response.');
   }

--- a/src/commands/explain.js
+++ b/src/commands/explain.js
@@ -93,6 +93,7 @@ export default async function explainCommand(args = [], deps = {}) {
   }
 
   log(`API mode — calling ${config.provider}...`);
+  log('');
   const walkthrough = await complete({
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
@@ -104,10 +105,8 @@ export default async function explainCommand(args = [], deps = {}) {
       scan: scanForPrompt,
       packageMeta: result.packageMeta,
     }),
+    onToken: (chunk) => process.stdout.write(chunk),
   });
-
-  log('');
-  log(walkthrough);
   log('');
 
   const flowsDir = join(draftwiseDir, 'flows');

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -206,6 +206,7 @@ export default async function newCommand(args = [], deps = {}) {
 
   log('');
   log(`Synthesizing product-spec.md (${config.provider})...`);
+  log('');
   const spec = await complete({
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
@@ -222,7 +223,9 @@ export default async function newCommand(args = [], deps = {}) {
       projectState: config.projectState,
       overview,
     }),
+    onToken: (chunk) => process.stdout.write(chunk),
   });
+  log('');
 
   const slug = slugify(plan.featureSlug);
   const specDir = join(draftwiseDir, 'specs', slug);

--- a/src/commands/scan.js
+++ b/src/commands/scan.js
@@ -107,6 +107,7 @@ export default async function scanCommand(_args = [], deps = {}) {
   }
 
   log(`API mode — calling ${config.provider}...`);
+  log('');
   const overview = await complete({
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
@@ -114,7 +115,9 @@ export default async function scanCommand(_args = [], deps = {}) {
     maxTokens: config.maxTokens,
     system: SYSTEM,
     prompt: buildPrompt({ scan: scanForPrompt, packageMeta: result.packageMeta }),
+    onToken: (chunk) => process.stdout.write(chunk),
   });
+  log('');
 
   await writeFile(join(draftwiseDir, 'overview.md'), overview, 'utf8');
   log('');

--- a/src/commands/tasks.js
+++ b/src/commands/tasks.js
@@ -154,6 +154,7 @@ export default async function tasksCommand(args = [], deps = {}) {
   }
 
   log(`API mode — calling ${config.provider}...`);
+  log('');
   const tasks = await complete({
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
@@ -167,7 +168,9 @@ export default async function tasksCommand(args = [], deps = {}) {
       projectState: config.projectState,
       overview,
     }),
+    onToken: (chunk) => process.stdout.write(chunk),
   });
+  log('');
 
   await writeFile(target.tasks, tasks, 'utf8');
   log('');

--- a/src/commands/tech.js
+++ b/src/commands/tech.js
@@ -155,6 +155,7 @@ export default async function techCommand(args = [], deps = {}) {
   }
 
   log(`API mode — calling ${config.provider}...`);
+  log('');
   const techSpec = await complete({
     provider: config.provider,
     apiKeyEnv: config.apiKeyEnv,
@@ -168,7 +169,9 @@ export default async function techCommand(args = [], deps = {}) {
       projectState: config.projectState,
       overview,
     }),
+    onToken: (chunk) => process.stdout.write(chunk),
   });
+  log('');
 
   await writeFile(target.technicalSpec, techSpec, 'utf8');
   log('');

--- a/test/ai/providers/claude.test.js
+++ b/test/ai/providers/claude.test.js
@@ -2,13 +2,14 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // Mock @anthropic-ai/sdk before importing claude.js — vi.mock is hoisted.
 const createMock = vi.fn();
+const streamMock = vi.fn();
 const constructorOpts = [];
 vi.mock('@anthropic-ai/sdk', () => {
   // The SDK's default export is a class; new-ing it must work.
   class FakeAnthropic {
     constructor(opts) {
       constructorOpts.push(opts);
-      this.messages = { create: createMock };
+      this.messages = { create: createMock, stream: streamMock };
     }
   }
   return { default: FakeAnthropic };
@@ -19,6 +20,7 @@ const { complete } = await import('../../../src/ai/providers/claude.js');
 describe('ai/providers/claude — complete()', () => {
   beforeEach(() => {
     createMock.mockReset();
+    streamMock.mockReset();
     constructorOpts.length = 0;
   });
 
@@ -141,5 +143,91 @@ describe('ai/providers/claude — complete()', () => {
     await expect(
       complete({ apiKey: 'sk', model: '', system: 's', prompt: 'p' }),
     ).rejects.toThrow(/429 Too Many Requests/);
+  });
+
+  describe('streaming via onToken', () => {
+    function fakeStream(events) {
+      return {
+        async *[Symbol.asyncIterator]() {
+          for (const e of events) yield e;
+        },
+      };
+    }
+
+    it('emits each text_delta to onToken and returns the accumulated string', async () => {
+      streamMock.mockReturnValue(
+        fakeStream([
+          { type: 'message_start' },
+          { type: 'content_block_start' },
+          { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hello ' } },
+          { type: 'content_block_delta', delta: { type: 'text_delta', text: 'world.' } },
+          { type: 'content_block_stop' },
+          { type: 'message_stop' },
+        ]),
+      );
+
+      const tokens = [];
+      const result = await complete({
+        apiKey: 'sk',
+        model: '',
+        system: 's',
+        prompt: 'p',
+        onToken: (chunk) => tokens.push(chunk),
+      });
+
+      expect(tokens).toEqual(['Hello ', 'world.']);
+      expect(result).toBe('Hello world.');
+      expect(createMock).not.toHaveBeenCalled();
+    });
+
+    it('ignores non-text-delta events while streaming', async () => {
+      streamMock.mockReturnValue(
+        fakeStream([
+          { type: 'content_block_delta', delta: { type: 'text_delta', text: 'A' } },
+          { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{}' } },
+          { type: 'content_block_delta', delta: { type: 'text_delta', text: 'B' } },
+          { type: 'message_stop' },
+        ]),
+      );
+
+      const tokens = [];
+      const result = await complete({
+        apiKey: 'sk',
+        model: '',
+        system: 's',
+        prompt: 'p',
+        onToken: (chunk) => tokens.push(chunk),
+      });
+
+      expect(tokens).toEqual(['A', 'B']);
+      expect(result).toBe('AB');
+    });
+
+    it('throws when the stream never emitted any text', async () => {
+      streamMock.mockReturnValue(fakeStream([{ type: 'message_stop' }]));
+      await expect(
+        complete({
+          apiKey: 'sk',
+          model: '',
+          system: 's',
+          prompt: 'p',
+          onToken: () => {},
+        }),
+      ).rejects.toThrow(/empty response/);
+    });
+
+    it('falls back to non-streaming when no onToken is given', async () => {
+      createMock.mockResolvedValue({
+        content: [{ type: 'text', text: 'whole thing' }],
+      });
+      const result = await complete({
+        apiKey: 'sk',
+        model: '',
+        system: 's',
+        prompt: 'p',
+      });
+      expect(result).toBe('whole thing');
+      expect(streamMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/test/commands/explain.test.js
+++ b/test/commands/explain.test.js
@@ -111,14 +111,14 @@ describe('draftwise explain', () => {
     expect(captured.system).toContain('Draftwise');
     expect(captured.prompt).toContain('"login"');
     expect(captured.prompt).toContain('Express');
+    // explain wires onToken so the walkthrough streams to stdout live.
+    expect(typeof captured.onToken).toBe('function');
 
     const saved = await readFile(
       join(dir, '.draftwise', 'flows', 'login.md'),
       'utf8',
     );
     expect(saved).toContain('# Flow: login');
-
-    expect(logs.join('\n')).toContain('# Flow: login');
   });
 
   it('short-circuits in greenfield mode with a friendly message', async () => {


### PR DESCRIPTION
scan, explain, new (spec phase), tech, and tasks now stream the model's output to stdout as it generates instead of waiting 10-30s on a frozen "Synthesizing..." line. Uses the Anthropic SDK's messages.stream() under the hood — claude.js gains an optional onToken callback that, when provided, takes the streaming path and accumulates the deltas for the return value. Without onToken, the existing non-streaming path runs unchanged.

JSON / plan calls (init questions, init stacks, new plan) deliberately don't stream — rendering JSON token-by-token would just dump a half-typed object on screen and be worse UX than the brief wait.

Closes the last P3 from the audit. Note: log lines and streamed content both go to stdout, so piping `draftwise scan > foo.md` mixes informational logs with the spec content. Future fix is to push log lines to stderr; out of scope here.