### PR TITLE
Clarify pass over CLI copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Each released version is tagged in git (`v0.0.1`, `v0.1.0`, etc.) and includes t
 
 ## [Unreleased]
 
+### Changed
+- **Clarify pass over CLI copy.** The init AI-config prompts now read as questions instead of bare labels (`'AI mode'` → `'How should Draftwise call the AI?'`, `'Which provider?'` → `'Which AI provider?'`, `'Environment variable holding the X API key'` → `'Which environment variable holds your X API key?'`). The greenfield Q&A and `new` clarifying-question prompts drop the stiff `Your answer (or press enter to skip):` suffix in favor of a `Why:` line and a `(press enter to skip)` hint. The `new` adjacent-opportunity prompt drops the redundant `Decision:` line — inquirer's choice list already speaks for itself. `Synthesizing product-spec.md` → `Drafting product-spec.md`, matching Draftwise's own vocabulary. `draftwise show` without a feature now leads its error with `Missing feature name.`, matching the pattern in `explain` and `new`. The `tech` HELP drops `inquirer picker` jargon for `prompts you to pick`. — Ankur (#TBD)
+
 ### Added
 - **Dependabot config** (`.github/dependabot.yml`) — weekly npm bumps + monthly GitHub Actions bumps. Dev tooling grouped so eslint / prettier / vitest land in a single PR. — Ankur (#TBD)
 - **Streaming wiring assertions in `scan`, `new`, `tech`, `tasks` tests.** Each api-mode test now verifies `typeof captured.onToken === 'function'`, so a refactor that drops streaming silently can't slip through. — Ankur (#TBD)

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -84,7 +84,7 @@ const DEFAULT_PROMPTS = {
     }),
   promptMode: () =>
     select({
-      message: 'AI mode',
+      message: 'How should Draftwise call the AI?',
       choices: [
         {
           name: 'Inside a coding agent (Claude Code, Cursor, Antigravity, etc.)',
@@ -101,7 +101,7 @@ const DEFAULT_PROMPTS = {
     }),
   promptProvider: () =>
     select({
-      message: 'Which provider?',
+      message: 'Which AI provider?',
       choices: [
         { name: 'Claude (Anthropic) — fully wired', value: 'claude' },
         { name: 'OpenAI — adapter not yet implemented', value: 'openai' },
@@ -110,7 +110,7 @@ const DEFAULT_PROMPTS = {
     }),
   promptApiKeyEnv: ({ provider, suggested }) =>
     input({
-      message: `Environment variable holding the ${provider} API key`,
+      message: `Which environment variable holds your ${provider} API key?`,
       default: suggested,
     }),
   promptIdea: () =>
@@ -121,7 +121,7 @@ const DEFAULT_PROMPTS = {
     }),
   askGreenfieldQuestion: ({ index, total, text, why }) =>
     input({
-      message: `Q${index + 1}/${total} — ${text}\n  (why: ${why})\n  Your answer (or press enter to skip):`,
+      message: `Q${index + 1}/${total} — ${text}\n  Why: ${why}\n  (press enter to skip)`,
     }),
   pickStack: ({ stackOptions }) =>
     select({

--- a/src/commands/new.js
+++ b/src/commands/new.js
@@ -39,11 +39,11 @@ the project plan (greenfield). Never invents files.
 const DEFAULT_PROMPTS = {
   askQuestion: ({ index, total, text, why }) =>
     input({
-      message: `Q${index + 1}/${total} — ${text}\n  (why: ${why})\n  Your answer (or press enter to skip):`,
+      message: `Q${index + 1}/${total} — ${text}\n  Why: ${why}\n  (press enter to skip)`,
     }),
   decideOpportunity: ({ index, total, flow, suggestion, rationale }) =>
     select({
-      message: `Opportunity ${index + 1}/${total} — adjacent change in "${flow}"\n  Suggestion: ${suggestion}\n  Why: ${rationale}\n  Decision:`,
+      message: `Opportunity ${index + 1}/${total} — adjacent change in "${flow}"\n  Suggestion: ${suggestion}\n  Why: ${rationale}`,
       choices: [
         { name: 'Accept — include in this spec', value: 'accepted' },
         { name: 'Decline — keep it out', value: 'declined' },
@@ -205,7 +205,7 @@ export default async function newCommand(args = [], deps = {}) {
   }
 
   log('');
-  log(`Synthesizing product-spec.md (${config.provider})...`);
+  log(`Drafting product-spec.md (${config.provider})...`);
   log('');
   const spec = await complete({
     provider: config.provider,

--- a/src/commands/show.js
+++ b/src/commands/show.js
@@ -41,7 +41,7 @@ export default async function showCommand(args = [], deps = {}) {
 
   if (!slug) {
     throw new Error(
-      'Usage: draftwise show <feature> [product|tech|tasks]  (default type: product)',
+      'Missing feature name. Usage: draftwise show <feature> [product|tech|tasks]  (default type: product)',
     );
   }
   if (!VALID_TYPES.includes(type)) {

--- a/src/commands/tech.js
+++ b/src/commands/tech.js
@@ -20,7 +20,7 @@ export const HELP = `draftwise tech [<feature>] — draft technical-spec.md from
 Usage:
   draftwise tech                 # auto-pick if exactly one product spec exists
   draftwise tech <feature-slug>  # target a specific feature
-  draftwise tech                 # multi-spec → inquirer picker
+  draftwise tech                 # multiple specs → prompts you to pick
 
 Reads the product spec, writes technical-spec.md grounded in the
 real codebase (brownfield) or the planned directory structure


### PR DESCRIPTION
## Summary
- Targeted clarity pass over user-facing CLI text — `init` prompts, the greenfield/`new` Q&A loop, the `new` opportunity loop, and a couple of error / HELP strings.
- Reworded label-style prompts as questions (`'AI mode'` → `'How should Draftwise call the AI?'`, etc.) so a first-time user can answer without inferring intent.
- Dropped a few stiff or redundant bits: the `Your answer (or press enter to skip):` suffix on Q&A prompts, the `Decision:` suffix above inquirer's own choice list, the `inquirer picker` jargon in `tech --help`, and the bare `Usage: ...` on `show`'s missing-arg error (now leads with `Missing feature name.` like `explain` / `new`).
- `Synthesizing` → `Drafting` for the spec-generation log line, matching Draftwise's own vocabulary.

No functionality moved — pure copy. README and CLAUDE.md are unchanged. CHANGELOG `[Unreleased]` updated.

## Test plan
- [x] `npm test` — 212/212 passing
- [x] `npm run lint` — clean
- [ ] Eyeball `draftwise init` (greenfield + brownfield) end-to-end after merge to confirm the new prompts render as expected
- [ ] Eyeball `draftwise new "<idea>"` to confirm the Q&A and opportunity prompts read cleanly