### PR TITLE
draftwise install-skill — bare /draftwise <verb> via standalone skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Each released version is tagged in git (`v0.0.1`, `v0.1.0`, etc.) and includes t
 
 ## [Unreleased]
 
+### Added
+
+- **`draftwise install-skill` / `uninstall-skill` — standalone Claude Code skill install for bare `/draftwise <verb>`.** New CLI commands that copy `plugin/skills/draftwise/` (SKILL.md + per-verb references) to `~/.claude/skills/draftwise/` (or `<cwd>/.claude/skills/draftwise/` with `--scope=project`). Why: the marketplace plugin path forces Claude Code's `<plugin>:<skill>` namespace, so `/plugin install draftwise` produces `/draftwise:draftwise <verb>` regardless of scope (user / project / project-this-user) — confirmed against [anthropics/claude-code#15882](https://github.com/anthropics/claude-code/issues/15882) (closed: not planned). A standalone skill written directly into `.claude/skills/` has no plugin manifest, so Claude Code lists it as a user/project skill with no namespace prefix — chat form becomes `/draftwise <verb>`, matching the CLI binary. Same pattern impeccable uses for its 22 bare verbs (`/audit`, `/polish`, etc.). Both install paths can coexist; the two slash forms appear side-by-side in `/help`. `package.json` `files` now ships `plugin/skills/` so the standalone install can resolve its source from the npm install. Source path resolves via `import.meta.url`; tests inject a temp `home` and `sourceDir` to keep the real `~/.claude/` untouched. `--force` overwrites an existing standalone install. `install-skill` and `uninstall-skill` validate `--scope` and reject unknown flags. — Ankur
+
+### Changed
+
+- **CLAUDE.md "Claude Code plugin" section corrected.** Previously claimed the marketplace plugin's user-facing slash form was `/draftwise <verb>` because plugin name and skill name match; that was wrong — plugin skills are *always* namespaced as `<plugin>:<skill>` and matching names doesn't collapse the prefix. Section now documents both install paths accurately, links to the relevant Claude Code issue, and notes that `package.json` `files` ships `plugin/skills/` (was previously stated as excluded). Stale `skills/draft/...` paths in the section also updated to `skills/draftwise/...` to match disk. — Ankur
+
 ## [0.2.0] — 2026-04-29 — Ankur
 
 The "Mode 1, for real" release. Draftwise now ships a Claude Code plugin so PMs drive spec drafting from `/draftwise <verb>` slash commands in chat — backed by a CLI that's been refactored to flags-first so non-TTY shells (CI, coding-agent harnesses) work without inquirer hanging on prompts.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,12 @@ test/                     → vitest, mirrors src structure
 plugin/                   → plugin source tree shipped via the marketplace
 ```
 
-**Claude Code plugin.** Distributed separately from the npm package — `.claude-plugin/marketplace.json` at repo root declares a single `draftwise` plugin with `source: ./plugin`. Inside `plugin/` is `.claude-plugin/plugin.json` (the install manifest) and `skills/draft/SKILL.md` plus `skills/draft/reference/<verb>.md` per CLI verb. **Plugin name is `draftwise` (matches npm package + brand); skill name is `draftwise` (matches CLI binary), so the user-facing slash form is `/draftwise <verb>`** — same word in chat and terminal. Pattern follows impeccable's distribution model: one skill routes to per-verb references that drive the conversation in chat and shell out to the npm-installed `draftwise` CLI. Users install via `/plugin marketplace add 4nkur/draftwise` in Claude Code, then `/plugin install draftwise`. The plugin is *not* shipped on npm — `package.json` `files` excludes the plugin directories. References include pre-flight checks (e.g. `new` warns if `overview.md` is stale, `tech` nudges to skim the product spec first) and tone shaping for how to ask the user about ambiguous flag values; they explicitly inherit `src/ai/prompts/principles.js`'s collaboration standards so the chat-driven conversation matches what the CLI's api-mode synthesis enforces.
+**Claude Code skill — two install paths.** `.claude-plugin/marketplace.json` at repo root declares a single `draftwise` plugin with `source: ./plugin`. Inside `plugin/` is `.claude-plugin/plugin.json` (the install manifest) and `skills/draftwise/SKILL.md` plus `skills/draftwise/reference/<verb>.md` per CLI verb. The same SKILL.md ships through two install paths with different slash-command shapes:
+
+- **Marketplace plugin** (`/plugin marketplace add 4nkur/draftwise` then `/plugin install draftwise`): Claude Code namespaces all plugin skills as `<plugin>:<skill>`, so the chat form is `/draftwise:draftwise <verb>`. The namespace prefix is mandatory for plugin-installed skills regardless of `/plugin install` scope (user / project / project-this-user) — see [anthropics/claude-code#15882](https://github.com/anthropics/claude-code/issues/15882) (closed: not planned).
+- **Standalone skill** (`draftwise install-skill`): writes `~/.claude/skills/draftwise/SKILL.md` (or `<cwd>/.claude/skills/draftwise/` with `--scope=project`) directly. No plugin manifest sits alongside it, so Claude Code reads it as a user/project skill — bare `/draftwise <verb>`, matching the CLI binary. Same pattern impeccable uses for its bare verbs at user level.
+
+Pattern follows impeccable's distribution model: one skill routes to per-verb references that drive the conversation in chat and shell out to the npm-installed `draftwise` CLI. The two install paths are independent and may coexist (you'll see both `/draftwise:draftwise <verb>` and `/draftwise <verb>` listed). `package.json` `files` ships `plugin/skills/` (so the standalone install can copy from `node_modules/draftwise/plugin/skills/draftwise/`) but excludes `plugin/.claude-plugin/`. References include pre-flight checks (e.g. `new` warns if `overview.md` is stale, `tech` nudges to skim the product spec first) and tone shaping for how to ask the user about ambiguous flag values; they explicitly inherit `src/ai/prompts/principles.js`'s collaboration standards so the chat-driven conversation matches what the CLI's api-mode synthesis enforces.
 
 The single most important module is `src/core/scanner.js` — it parses the user's codebase and produces a structured representation everything else builds on. Get that right and the rest follows.
 
@@ -137,6 +142,8 @@ draftwise tech [<feature>] [--force]    → drafts technical-spec.md from approv
 draftwise tasks [<feature>] [--force]   → ordered tasks.md from technical spec
 draftwise list                          → list all specs in .draftwise/specs/
 draftwise show <feature> [type]         → display a spec (type: product | tech | tasks; default: product)
+draftwise install-skill [--scope=...] [--force]   → install Draftwise as a standalone Claude Code skill (bare /draftwise <verb>)
+draftwise uninstall-skill [--scope=...]           → remove a standalone skill install
 ```
 
 Each command is a separate file under `src/commands/` with a single `export default async function(args, deps = {}) {}`. The `deps` object is the dependency-injection seam used by tests — `cwd`, `log`, `scan`, `loadConfig`, `complete`, and per-command prompt overrides.

--- a/README.md
+++ b/README.md
@@ -95,14 +95,21 @@ cd your-project          # existing repo, or an empty directory for a new projec
 draftwise init
 ```
 
-**Optional — slash commands inside Claude Code.** If you use Claude Code, install the Draftwise plugin so `/draftwise init`, `/draftwise new "<idea>"`, etc. work in chat:
+**Optional — slash commands inside Claude Code.** Two paths, same skill, different slash-command shape:
 
-```
-/plugin marketplace add 4nkur/draftwise
-/plugin install draftwise
-```
+- **Bare `/draftwise <verb>` (recommended — matches the CLI binary).** After `npm install -g draftwise`, run:
+  ```
+  draftwise install-skill
+  ```
+  Drops a standalone skill at `~/.claude/skills/draftwise/`. Slash form is `/draftwise init`, `/draftwise new "<idea>"`, etc. Add `--scope=project` to install at `<cwd>/.claude/skills/draftwise/` instead. Remove with `draftwise uninstall-skill`.
+- **`/draftwise:draftwise <verb>` via the plugin marketplace.** If you prefer Claude Code's `/plugin` workflow:
+  ```
+  /plugin marketplace add 4nkur/draftwise
+  /plugin install draftwise
+  ```
+  Claude Code namespaces all plugin skills as `<plugin>:<skill>`, so the chat form is `/draftwise:draftwise <verb>` regardless of install scope.
 
-The plugin shells out to the same `draftwise` CLI — install Draftwise via npm first.
+Both paths shell out to the same `draftwise` CLI — install Draftwise via npm first. The two paths are independent and may coexist.
 
 `draftwise init` first asks whether you're starting **greenfield** (no code yet) or **brownfield** (existing codebase) and routes accordingly:
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "files": [
     "bin",
     "src",
+    "plugin/skills",
     "README.md",
     "LICENSE"
   ],

--- a/src/commands/install-skill.js
+++ b/src/commands/install-skill.js
@@ -1,0 +1,102 @@
+import { cp, rm } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+import { parseArgs } from 'node:util';
+import { pathExists } from '../utils/fs.js';
+
+export const HELP = `draftwise install-skill — install Draftwise as a standalone Claude Code skill
+
+Usage:
+  draftwise install-skill                  # install at user scope (~/.claude/skills/draftwise/)
+  draftwise install-skill --scope=project  # install at <cwd>/.claude/skills/draftwise/
+  draftwise install-skill --force          # overwrite an existing install
+
+Flags:
+  --scope=<user|project>     Where to write SKILL.md (default: user)
+  --force                    Overwrite an existing draftwise/ skill dir
+
+Drops a standalone SKILL.md (plus per-verb references) directly into
+the Claude Code skills directory. Unlike the marketplace plugin —
+which Claude Code namespaces as /draftwise:draftwise <verb> — a
+standalone install gives you bare slash commands: /draftwise <verb>,
+matching the CLI binary.
+
+The npm-installed CLI still drives the work; the skill just shells
+out to \`draftwise <verb>\`. The two install paths are independent
+and may coexist (you'll see both forms in Claude Code).
+`;
+
+const ARG_OPTIONS = {
+  scope: { type: 'string' },
+  force: { type: 'boolean' },
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// src/commands/install-skill.js → ../../plugin/skills/draftwise/
+const DEFAULT_SOURCE_DIR = resolve(
+  __dirname,
+  '..',
+  '..',
+  'plugin',
+  'skills',
+  'draftwise',
+);
+
+function resolveTarget(scope, cwd, home) {
+  if (scope === 'project') return join(cwd, '.claude', 'skills', 'draftwise');
+  return join(home, '.claude', 'skills', 'draftwise');
+}
+
+export default async function installSkillCommand(args = [], deps = {}) {
+  const cwd = deps.cwd ?? process.cwd();
+  const log = deps.log ?? ((m) => console.log(m));
+  const home = deps.home ?? homedir();
+  const sourceDir = deps.sourceDir ?? DEFAULT_SOURCE_DIR;
+
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args,
+      options: ARG_OPTIONS,
+      allowPositionals: false,
+      strict: true,
+    });
+  } catch (err) {
+    throw new Error(
+      `Invalid arguments to draftwise install-skill: ${err.message}`,
+      { cause: err },
+    );
+  }
+
+  const scope = parsed.values.scope ?? 'user';
+  if (scope !== 'user' && scope !== 'project') {
+    throw new Error(
+      `Invalid --scope value: ${scope}. Use --scope=user or --scope=project.`,
+    );
+  }
+  const force = Boolean(parsed.values.force);
+
+  if (!(await pathExists(sourceDir))) {
+    throw new Error(
+      `Skill source not found at ${sourceDir}. Try reinstalling draftwise: npm i -g draftwise.`,
+    );
+  }
+
+  const target = resolveTarget(scope, cwd, home);
+  if (await pathExists(target)) {
+    if (!force) {
+      throw new Error(
+        `${target} already exists. Pass --force to overwrite, or run \`draftwise uninstall-skill\` first.`,
+      );
+    }
+    await rm(target, { recursive: true, force: true });
+  }
+
+  await cp(sourceDir, target, { recursive: true });
+
+  log(`Installed Draftwise skill at ${target}`);
+  log('');
+  log('Slash command:  /draftwise <verb>');
+  log('Try it:         /draftwise init');
+}

--- a/src/commands/uninstall-skill.js
+++ b/src/commands/uninstall-skill.js
@@ -1,0 +1,66 @@
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { parseArgs } from 'node:util';
+import { pathExists } from '../utils/fs.js';
+
+export const HELP = `draftwise uninstall-skill — remove a standalone Draftwise skill install
+
+Usage:
+  draftwise uninstall-skill                  # remove ~/.claude/skills/draftwise/
+  draftwise uninstall-skill --scope=project  # remove <cwd>/.claude/skills/draftwise/
+
+Flags:
+  --scope=<user|project>     Which install to remove (default: user)
+
+Removes only the standalone skill dir created by \`draftwise
+install-skill\`. The marketplace plugin (if installed) is untouched —
+manage that via Claude Code's /plugin uninstall.
+`;
+
+const ARG_OPTIONS = {
+  scope: { type: 'string' },
+};
+
+function resolveTarget(scope, cwd, home) {
+  if (scope === 'project') return join(cwd, '.claude', 'skills', 'draftwise');
+  return join(home, '.claude', 'skills', 'draftwise');
+}
+
+export default async function uninstallSkillCommand(args = [], deps = {}) {
+  const cwd = deps.cwd ?? process.cwd();
+  const log = deps.log ?? ((m) => console.log(m));
+  const home = deps.home ?? homedir();
+
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args,
+      options: ARG_OPTIONS,
+      allowPositionals: false,
+      strict: true,
+    });
+  } catch (err) {
+    throw new Error(
+      `Invalid arguments to draftwise uninstall-skill: ${err.message}`,
+      { cause: err },
+    );
+  }
+
+  const scope = parsed.values.scope ?? 'user';
+  if (scope !== 'user' && scope !== 'project') {
+    throw new Error(
+      `Invalid --scope value: ${scope}. Use --scope=user or --scope=project.`,
+    );
+  }
+
+  const target = resolveTarget(scope, cwd, home);
+  if (!(await pathExists(target))) {
+    throw new Error(
+      `No standalone Draftwise skill at ${target}. (Wrong --scope?)`,
+    );
+  }
+
+  await rm(target, { recursive: true, force: true });
+  log(`Removed ${target}`);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,8 @@ const COMMANDS = {
   list: () => import('./commands/list.js'),
   show: () => import('./commands/show.js'),
   scaffold: () => import('./commands/scaffold.js'),
+  'install-skill': () => import('./commands/install-skill.js'),
+  'uninstall-skill': () => import('./commands/uninstall-skill.js'),
 };
 
 const HELP = `draftwise — codebase-aware spec drafting
@@ -31,6 +33,8 @@ Commands:
   tasks [<feature>]             Generate ordered tasks.md from technical spec
   list                          List all specs in .draftwise/specs/
   show <feature> [type]         Show a spec (type: product | tech | tasks; default: product)
+  install-skill                 Install Draftwise as a standalone Claude Code skill (bare /draftwise <verb>)
+  uninstall-skill               Remove a standalone skill install
 
 Flags:
   -h, --help                    Show this help (or per-command help when after a command)

--- a/test/commands/install-skill.test.js
+++ b/test/commands/install-skill.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  mkdtemp,
+  rm,
+  mkdir,
+  writeFile,
+  readFile,
+  readdir,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import installSkill from '../../src/commands/install-skill.js';
+
+async function seedSource(root) {
+  const src = join(root, 'plugin-skills', 'draftwise');
+  await mkdir(join(src, 'reference'), { recursive: true });
+  await writeFile(
+    join(src, 'SKILL.md'),
+    '---\nname: draftwise\n---\n\nbody\n',
+    'utf8',
+  );
+  await writeFile(join(src, 'reference', 'init.md'), 'init ref\n', 'utf8');
+  await writeFile(join(src, 'reference', 'new.md'), 'new ref\n', 'utf8');
+  return src;
+}
+
+describe('draftwise install-skill', () => {
+  let workspace;
+  let home;
+  let cwd;
+  let sourceDir;
+  let logs;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'draftwise-install-'));
+    home = join(workspace, 'home');
+    cwd = join(workspace, 'project');
+    await mkdir(home, { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    sourceDir = await seedSource(workspace);
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  function deps(extra = {}) {
+    return { cwd, home, sourceDir, log: (m) => logs.push(m), ...extra };
+  }
+
+  it('writes SKILL.md and references at user scope by default', async () => {
+    await installSkill([], deps());
+
+    const target = join(home, '.claude', 'skills', 'draftwise');
+    const skill = await readFile(join(target, 'SKILL.md'), 'utf8');
+    expect(skill).toContain('name: draftwise');
+
+    const refs = await readdir(join(target, 'reference'));
+    expect(refs.sort()).toEqual(['init.md', 'new.md']);
+  });
+
+  it('writes to <cwd>/.claude/skills/draftwise when --scope=project', async () => {
+    await installSkill(['--scope=project'], deps());
+
+    const target = join(cwd, '.claude', 'skills', 'draftwise');
+    const skill = await readFile(join(target, 'SKILL.md'), 'utf8');
+    expect(skill).toContain('name: draftwise');
+  });
+
+  it('rejects an unknown --scope value', async () => {
+    await expect(installSkill(['--scope=global'], deps())).rejects.toThrow(
+      /Invalid --scope value: global/,
+    );
+  });
+
+  it('refuses to overwrite an existing install without --force', async () => {
+    await installSkill([], deps());
+    await expect(installSkill([], deps())).rejects.toThrow(/already exists/);
+  });
+
+  it('replaces an existing install when --force is passed', async () => {
+    await installSkill([], deps());
+    const target = join(home, '.claude', 'skills', 'draftwise');
+    // Add a stale file that the next install should clear out.
+    await writeFile(join(target, 'reference', 'stale.md'), 'old', 'utf8');
+
+    await installSkill(['--force'], deps());
+
+    const refs = await readdir(join(target, 'reference'));
+    expect(refs).not.toContain('stale.md');
+    expect(refs.sort()).toEqual(['init.md', 'new.md']);
+  });
+
+  it('errors clearly when the skill source is missing', async () => {
+    await rm(sourceDir, { recursive: true, force: true });
+    await expect(installSkill([], deps())).rejects.toThrow(
+      /Skill source not found/,
+    );
+  });
+
+  it('rejects unknown flags', async () => {
+    await expect(installSkill(['--scopes=user'], deps())).rejects.toThrow(
+      /Invalid arguments/,
+    );
+  });
+});

--- a/test/commands/uninstall-skill.test.js
+++ b/test/commands/uninstall-skill.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathExists } from '../../src/utils/fs.js';
+import uninstallSkill from '../../src/commands/uninstall-skill.js';
+
+describe('draftwise uninstall-skill', () => {
+  let workspace;
+  let home;
+  let cwd;
+  let logs;
+
+  beforeEach(async () => {
+    workspace = await mkdtemp(join(tmpdir(), 'draftwise-uninstall-'));
+    home = join(workspace, 'home');
+    cwd = join(workspace, 'project');
+    await mkdir(home, { recursive: true });
+    await mkdir(cwd, { recursive: true });
+    logs = [];
+  });
+
+  afterEach(async () => {
+    await rm(workspace, { recursive: true, force: true });
+  });
+
+  function deps(extra = {}) {
+    return { cwd, home, log: (m) => logs.push(m), ...extra };
+  }
+
+  async function seedTarget(root) {
+    const target = join(root, '.claude', 'skills', 'draftwise');
+    await mkdir(join(target, 'reference'), { recursive: true });
+    await writeFile(join(target, 'SKILL.md'), 'body', 'utf8');
+    await writeFile(join(target, 'reference', 'init.md'), 'r', 'utf8');
+    return target;
+  }
+
+  it('removes the user-scope skill dir', async () => {
+    const target = await seedTarget(home);
+    await uninstallSkill([], deps());
+    expect(await pathExists(target)).toBe(false);
+  });
+
+  it('removes the project-scope skill dir when --scope=project', async () => {
+    const target = await seedTarget(cwd);
+    await uninstallSkill(['--scope=project'], deps());
+    expect(await pathExists(target)).toBe(false);
+  });
+
+  it('errors when there is nothing to remove', async () => {
+    await expect(uninstallSkill([], deps())).rejects.toThrow(
+      /No standalone Draftwise skill at/,
+    );
+  });
+
+  it('rejects an unknown --scope value', async () => {
+    await expect(uninstallSkill(['--scope=other'], deps())).rejects.toThrow(
+      /Invalid --scope value: other/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `draftwise install-skill` (and `uninstall-skill`) so users can install Draftwise as a **standalone Claude Code skill** at `~/.claude/skills/draftwise/` (or `<cwd>/.claude/skills/draftwise/` with `--scope=project`). Slash form: `/draftwise <verb>` — bare, no namespace, matches the CLI binary.
- The existing marketplace plugin path is unchanged; it still produces `/draftwise:draftwise <verb>` because Claude Code namespaces all plugin skills as `<plugin>:<skill>` regardless of `/plugin install` scope (see [anthropics/claude-code#15882](https://github.com/anthropics/claude-code/issues/15882) — closed: not planned). Both install paths coexist.
- `package.json` `files` now ships `plugin/skills/` so the standalone install can copy its source from the npm install; `plugin/.claude-plugin/` is still excluded.
- CLAUDE.md "Claude Code plugin" section corrected — previously claimed matching plugin and skill names collapse the namespace, which is false. Now documents both paths accurately, links to the upstream issue, and updates stale `skills/draft/...` paths to `skills/draftwise/...`. CHANGELOG `[Unreleased]` gets Added + Changed entries.

## Test plan

- [x] `npm test` — 278/278 passing (11 new tests across `install-skill` and `uninstall-skill`)
- [x] `npm run lint` — clean
- [x] Smoke-tested the binary: `node bin/draftwise.js install-skill` writes the expected files; `node bin/draftwise.js uninstall-skill` removes them
- [x] `node bin/draftwise.js --help` lists the new commands
- [x] `node bin/draftwise.js install-skill --help` shows the per-command help

## Notes

- The two install paths produce two separate entries in `/help`: `/draftwise:draftwise <verb>` (marketplace) and `/draftwise <verb>` (standalone). Users can pick either — the underlying CLI is the same.
- Tests inject a temp `home` and `sourceDir` so the real `~/.claude/` stays untouched.