### PR TITLE
Pre-publish tidy: fix `draft` → `draftwise` typos and drop dead prompt aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ Each released version is tagged in git (`v0.0.1`, `v0.1.0`, etc.) and includes t
 
 - **CLAUDE.md "Claude Code plugin" section corrected and expanded.** Originally claimed the marketplace plugin's user-facing slash form was `/draftwise <verb>` because plugin name and skill name match; that was wrong — plugin skills are *always* namespaced as `<plugin>:<skill>` and matching names doesn't collapse the prefix. Section now documents both install paths (marketplace + standalone) accurately, links the relevant Claude Code issue, lists the three harnesses the standalone path supports today, and notes that `package.json` `files` ships `plugin/skills/` (previously stated as excluded). Stale `skills/draft/...` paths updated to `skills/draftwise/...`. The `src/utils/` + commands list now includes `skill-providers.js` and `src/commands/skills/{install,uninstall,help}.js`. — Ankur
 
+### Fixed
+
+- **Two user-visible error messages referenced a non-existent `draft` binary instead of `draftwise`.** `src/commands/show.js` printed `Run \`draft new\` to generate it.` when a missing spec type was requested; `src/ai/provider.js` printed `or run draft inside a coding agent.` when the OpenAI / Gemini stub adapter was hit. Both now spell the binary correctly. Caught during a pre-publish audit; relics from an earlier rename when the package was briefly called `draft`. — Ankur
+
+### Removed
+
+- **Dead backwards-compat aliases on the prompt modules.** `src/ai/prompts/new.js` exported `PLAN_SYSTEM` / `SPEC_SYSTEM` and `src/ai/prompts/{tech,tasks}.js` each exported a top-level `SYSTEM` — three aliases marked "Backwards compatibility — keep the old names alive" that never had real callers. Verified by grep across `src/` and `test/`: every consumer either uses the explicit `_BROWNFIELD` / `_GREENFIELD` constants or the `selectSystem` / `selectPlanSystem` / `selectSpecSystem` helpers. The package hasn't shipped a version where these were the canonical names, so there's no compat to preserve. Pre-publish hygiene: shrink the public API surface before users import what we don't intend to support. `scan.js` and `explain.js` keep their `SYSTEM` exports — those are primary, not aliases, and are imported by the matching command files. — Ankur
+
 ## [0.2.0] — 2026-04-29 — Ankur
 
 The "Mode 1, for real" release. Draftwise now ships a Claude Code plugin so PMs drive spec drafting from `/draftwise <verb>` slash commands in chat — backed by a CLI that's been refactored to flags-first so non-TTY shells (CI, coding-agent harnesses) work without inquirer hanging on prompts.

--- a/src/ai/prompts/new.js
+++ b/src/ai/prompts/new.js
@@ -363,7 +363,3 @@ PHASE 3 — Generate product-spec.md:
 
 Hard rules: ground every claim in the scanner; turn every gap into a question, not an assumption; keep the spec tight.`;
 }
-
-// Backwards compatibility — keep the old names alive as aliases.
-export const PLAN_SYSTEM = PLAN_SYSTEM_BROWNFIELD;
-export const SPEC_SYSTEM = SPEC_SYSTEM_BROWNFIELD;

--- a/src/ai/prompts/tasks.js
+++ b/src/ai/prompts/tasks.js
@@ -82,9 +82,6 @@ Hard rules:
 - Output markdown only. No preamble.
 `;
 
-// Backwards-compatible default
-export const SYSTEM = SYSTEM_BROWNFIELD;
-
 export function selectSystem(projectState) {
   return projectState === 'greenfield' ? SYSTEM_GREENFIELD : SYSTEM_BROWNFIELD;
 }

--- a/src/ai/prompts/tech.js
+++ b/src/ai/prompts/tech.js
@@ -86,9 +86,6 @@ Hard rules:
 - Keep it tight. Output markdown only, no preamble.
 `;
 
-// Backwards-compatible default
-export const SYSTEM = SYSTEM_BROWNFIELD;
-
 export function selectSystem(projectState) {
   return projectState === 'greenfield' ? SYSTEM_GREENFIELD : SYSTEM_BROWNFIELD;
 }

--- a/src/ai/provider.js
+++ b/src/ai/provider.js
@@ -9,7 +9,7 @@ const ADAPTERS = {
 function notImplemented(name) {
   return () => {
     throw new Error(
-      `The ${name} provider isn't wired up yet. Use Claude for now (set ai.provider: claude in .draftwise/config.yaml) or run draft inside a coding agent.`,
+      `The ${name} provider isn't wired up yet. Use Claude for now (set ai.provider: claude in .draftwise/config.yaml) or run draftwise inside a coding agent.`,
     );
   };
 }

--- a/src/commands/show.js
+++ b/src/commands/show.js
@@ -67,7 +67,7 @@ export default async function showCommand(args = [], deps = {}) {
   const filePath = target[TYPE_TO_FILE[type]];
   if (!(await pathExists(filePath))) {
     throw new Error(
-      `${TYPE_TO_FILENAME[type]} not found for "${slug}". Run \`draft ${type === 'product' ? 'new' : type}\` to generate it.`,
+      `${TYPE_TO_FILENAME[type]} not found for "${slug}". Run \`draftwise ${type === 'product' ? 'new' : type}\` to generate it.`,
     );
   }
 


### PR DESCRIPTION
## Summary

Pre-publish hygiene PR caught during a v0.2.0 → v0.3.x audit. Two halves, both safe:

- **Fix two user-visible error messages that referenced a non-existent `draft` binary.** `src/commands/show.js` printed `Run \`draft new\` to generate it.` when asked for a missing spec type; `src/ai/provider.js` printed `or run draft inside a coding agent.` when the OpenAI / Gemini stub adapter fired. Relics from a pre-rename era when the package was briefly called `draft`. Both spell `draftwise` now.
- **Drop three dead "backwards compatibility" aliases on the prompt modules.** `PLAN_SYSTEM` / `SPEC_SYSTEM` in `src/ai/prompts/new.js` and the top-level `SYSTEM` exports in `src/ai/prompts/{tech,tasks}.js` were marked "keep the old names alive" but never had real callers — every consumer in `src/` and `test/` uses the `_BROWNFIELD` / `_GREENFIELD` constants or the `selectSystem` helpers. The package hasn't shipped a version where these were the canonical names, so there's nothing to preserve. Shrink the public API surface before users import what we don't intend to support. `scan.js` and `explain.js` keep their `SYSTEM` exports because those are primary, not aliases.

CHANGELOG `[Unreleased]` gains a `### Fixed` entry for the typos and a `### Removed` entry for the alias deletion.

## Test plan

- [x] `npm test` — 307 passing (33 files), unchanged from main
- [x] `npm run lint` — clean
- [x] No README or CLAUDE.md changes needed (typos in error strings; alias removal is internal)
- [x] `npm pack --dry-run` tarball still 53 files / 68 kB