### PR TITLE
Release prep — bump to 0.2.1 and roll up CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Each released version is tagged in git (`v0.0.1`, `v0.1.0`, etc.) and includes t
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-04-29 — Ankur
+
+The polish + cleanup release. Half ergonomic improvements (init now auto-detects new project vs existing codebase from the filesystem instead of asking; plain-language UX throughout init), half code-quality work (five small dedup + tidy PRs that shrink the public API surface, fix two user-visible typos, and consolidate the drafting-command boilerplate behind shared helpers). One genuinely new surface: `draftwise skills <install|uninstall|help>` drops standalone slash-command skills into Claude Code, Cursor, and Gemini CLI's user-level skill dirs — same SKILL.md, per-provider frontmatter trim — independent of the Claude Code marketplace plugin.
+
+Bumps `package.json` + `package-lock.json` from 0.2.0 → 0.2.1 (patch — additive `skills` verb is non-breaking; the removed prompt aliases were never imported by anyone outside this repo, verified by audit). Rolls all [Unreleased] entries into [0.2.1] — 2026-04-29 — Ankur, with a fresh empty [Unreleased] block above.
+
+After merge, ritual: `git tag -a v0.2.1 -m "v0.2.1"`, `git push origin v0.2.1`, `npm publish` (interactive — OTP + login may be needed if the npm session expired).
+
 ### Changed
 
 - **`draftwise init` auto-detects new project vs existing codebase from the filesystem.** Previously asked the user (Q1 in the structured handoff and the first interactive prompt) whether the project was greenfield or brownfield. Now walks the cwd using `src/utils/project-state.js` (which reuses scanner.js's `IGNORE_DIRS` + `CODE_EXTENSIONS`) and bails on the first source file: zero source files → greenfield; one or more → brownfield. The result is logged in plain language ("Detected: new project — no source files yet" / "Detected: existing codebase — source files already in this directory") with an explicit override hint (`--mode=greenfield|brownfield`). The structured handoff opens with the detected state on its first line so the host coding agent can relay it to the user without re-running detection. Why: in non-TTY usage (which is now the primary path through Claude Code), the project state is almost always determinable from the filesystem — asking is pure friction, and the user's own placementos test exposed it. Frame: detection is the default, the flag is the override. Removes `promptProjectState` and the `mode` resolveValue branch from `init.js`. — Ankur

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "draftwise",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "draftwise",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "draftwise",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Codebase-aware product specs. AI scans your repo, then drafts specs that fit it.",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

The polish + cleanup release. Rolls everything since 0.2.0 (PRs #51–#57) into a versioned section.

**Theme.** Half ergonomic improvements (init auto-detects new-vs-existing project from the filesystem; plain-language UX), half code-quality work (5 small dedup + tidy PRs). One genuinely new surface: `draftwise skills <install|uninstall|help>` for Claude Code / Cursor / Gemini CLI standalone skill installs.

**Why patch (0.2.1) and not minor (0.3.0).** The additive `skills` verb is non-breaking; the removed prompt aliases (`PLAN_SYSTEM`, `SPEC_SYSTEM`, `tech.SYSTEM`, `tasks.SYSTEM`) were never imported outside this repo, audited by grep. Conservative bump per project convention. **If you want to flag the new `skills` surface louder for users — bump this to 0.3.0 before merging.** Just edit `package.json` + `package-lock.json` + the CHANGELOG header. No code change needed.

**What's in the release** (all entries already drafted under `[0.2.1]` in CHANGELOG):

- Changed: `init` auto-detects from filesystem
- Changed: plain-language init UX
- Added: `draftwise skills <install|uninstall|help>`
- Changed: CLAUDE.md plugin-section correction
- Fixed: two `draft` → `draftwise` typos
- Changed: `scan` reuses `compactScan`
- Changed: `extractJsonFromFence` extracted to shared util
- Changed: `loadAnswersFlag` extracted to shared util
- Changed: drafting-command boilerplate extracted (3 helpers)
- Removed: dead backwards-compat prompt aliases

## Verification

- [x] `npm test` — 332 passing (38 files)
- [x] `npm run lint` — clean
- [x] `npm pack --dry-run` — 58 files, 69 kB tarball, 227.7 kB unpacked. No surprises (5 new util files vs 0.2.0's 53)
- [x] `prepublishOnly` will run `npm test && npm run lint` again at publish time

## After merge — ritual

```
git checkout main && git pull
git tag -a v0.2.1 -m "v0.2.1"
git push origin v0.2.1
npm publish    # interactive: OTP + login if session expired
gh release create v0.2.1 --notes-from-tag    # or paste the [0.2.1] CHANGELOG section
```